### PR TITLE
Mesh lib

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -36,3 +36,10 @@ bases:
 provides:
   service-mesh:
     interface: service_mesh
+
+parts:
+  charm:
+    charm-binary-python-packages:
+      # Pydantic is not actually used by the lib but charmcraft install pydeps from libs even if
+      # they are not used.
+      - pydantic>2.0

--- a/lib/charms/istio_beacon_k8s/v0/service_mesh.py
+++ b/lib/charms/istio_beacon_k8s/v0/service_mesh.py
@@ -1,0 +1,119 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""#Service Mesh Library.
+
+The service mesh library is used to facilitate adding you charmed application to a service mesh.
+The library leverages the `service_mesh` interface and the `cross_model_mesh` interface
+
+To add service mesh support to your charm, instantiate a ServiceMeshConsumer object in the
+`__init__` method of your charm:
+
+```
+from charms.istio_beacon_k8s.v0.service_mesh import IsCrossModelError, Policy, ServiceMeshConsumer
+
+...
+self._mesh = ServiceMeshConsumer(
+    self,
+    policies=[
+        Policy(relation="logging", endpoints=[f"*:{HTTP_LISTEN_PORT}"]),
+    ],
+)
+```
+"""
+
+import json
+import logging
+import re
+from typing import List, Optional
+
+import pydantic
+from ops import CharmBase, Object
+
+LIBID = "3f40cb7e3569454a92ac2541c5ca0a0c"  # Never change this
+LIBAPI = 0
+LIBPATCH = 1
+
+logger = logging.getLogger(__name__)
+
+
+class Policy(pydantic.BaseModel):
+    """Data type for holding a service mesh policy."""
+
+    relation: str
+    endpoints: List[str]
+
+
+class ServiceMeshConsumer(Object):
+    """Class for managing the consumer side of the service_mesh relation interface."""
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        mesh_relation_name: str = "service-mesh",
+        policies: Optional[List[Policy]] = None,
+    ):
+        """Class used for joining a service mesh.
+
+        Args:
+            charm: The charm instantiating this object.
+            mesh_relation_name: The relation name as defined in metadata.yaml or charmcraft.yaml
+                for the relation which used the service_mesh interface.
+            policies: List of access policies this charm supports.
+        """
+        super().__init__(charm, mesh_relation_name)
+        self._charm = charm
+        self._relations = self._charm.model.relations[mesh_relation_name]
+        self._policies = policies or []
+        self.framework.observe(
+            self._charm.on[mesh_relation_name].relation_created, self._relations_changed
+        )
+        self.framework.observe(self._charm.on.upgrade_charm, self._relations_changed)
+        for policy in self._policies:
+            self.framework.observe(
+                self._charm.on[policy.relation].relation_created, self._relations_changed
+            )
+            self.framework.observe(
+                self._charm.on[policy.relation].relation_broken, self._relations_changed
+            )
+
+    def _relations_changed(self, _event):
+        self.update_service_mesh()
+
+    def update_service_mesh(self):
+        """Update the service mesh.
+
+        Gathers information from all relations of the charm and updates the mesh appropriately to
+        allow communication.
+        """
+        logger.debug("Updating service mesh policies.")
+        policies = []
+        cmr_matcher = re.compile(r"remote\-[a-f0-9]+")
+        for policy in self._policies:
+            for relation in self._charm.model.relations[policy.relation]:
+                if cmr_matcher.fullmatch(relation.app.name):
+                    logger.debug(
+                        f"Cross model relation found: {relation.name}. Currently not implemented. Skipping."
+                    )
+                else:
+                    logger.debug(f"Found relation: {relation.name}. Creating policy.")
+                    policies.append(
+                        {
+                            "app_name": relation.app.name,
+                            "namespace": self._my_namespace(),
+                            "endpoints": policy.endpoints,
+                        }
+                    )
+        mesh_rel_data = {
+            "app_name": self._charm.app.name,
+            "model": self._my_namespace(),
+            "policies": policies,
+        }
+        for rel in self._relations:
+            rel.data[self._charm.app]["mesh_data"] = json.dumps(mesh_rel_data)
+
+    def _my_namespace(self):
+        """Return the namespace of the running charm."""
+        # This method currently assumes the namespace is the same as the model name. We
+        # should consider if there is a better way to do this.
+        return self._charm.model.name

--- a/lib/charms/istio_beacon_k8s/v0/service_mesh.py
+++ b/lib/charms/istio_beacon_k8s/v0/service_mesh.py
@@ -57,14 +57,20 @@ class Method(str, enum.Enum):
     trace = "TRACE"
 
 
-class Policy(pydantic.BaseModel):
-    """Data type for holding a service mesh policy."""
+class Endpoint(pydantic.BaseModel):
+    """Data type for a policy endpoint."""
 
-    relation: str
     hosts: List[str]
     ports: List[int]
     methods: List[Method]
     paths: List[str]
+
+
+class Policy(pydantic.BaseModel):
+    """Data type for holding a service mesh policy."""
+
+    relation: str
+    endpoints: List[Endpoint]
 
 
 class ServiceMeshConsumer(Object):

--- a/lib/charms/istio_beacon_k8s/v0/service_mesh.py
+++ b/lib/charms/istio_beacon_k8s/v0/service_mesh.py
@@ -3,7 +3,7 @@
 
 """#Service Mesh Library.
 
-The service mesh library is used to facilitate adding you charmed application to a service mesh.
+The service mesh library is used to facilitate adding your charmed application to a service mesh.
 The library leverages the `service_mesh` interface and the `cross_model_mesh` interface
 
 To add service mesh support to your charm, instantiate a ServiceMeshConsumer object in the

--- a/lib/charms/istio_beacon_k8s/v0/service_mesh.py
+++ b/lib/charms/istio_beacon_k8s/v0/service_mesh.py
@@ -92,7 +92,7 @@ class ServiceMeshConsumer(Object):
         """
         super().__init__(charm, mesh_relation_name)
         self._charm = charm
-        self._relation = self._charm.model.get_relation[mesh_relation_name]
+        self._relation = self._charm.model.get_relation(mesh_relation_name)
         self._policies = policies or []
         self.framework.observe(
             self._charm.on[mesh_relation_name].relation_created, self._relations_changed
@@ -115,6 +115,8 @@ class ServiceMeshConsumer(Object):
         Gathers information from all relations of the charm and updates the mesh appropriately to
         allow communication.
         """
+        if self._relation is None:
+            return
         logger.debug("Updating service mesh policies.")
         policies = []
         cmr_matcher = re.compile(r"remote\-[a-f0-9]+")

--- a/lib/charms/istio_beacon_k8s/v0/service_mesh.py
+++ b/lib/charms/istio_beacon_k8s/v0/service_mesh.py
@@ -133,7 +133,7 @@ class ServiceMeshConsumer(Object):
                         {
                             "app_name": relation.app.name,
                             "namespace": self._my_namespace(),
-                            "endpoints": policy.endpoints,
+                            "endpoints": [endpoint.model_dump() for endpoint in policy.endpoints],
                             "service": policy.service,
                         }
                     )

--- a/lib/charms/istio_beacon_k8s/v0/service_mesh.py
+++ b/lib/charms/istio_beacon_k8s/v0/service_mesh.py
@@ -48,7 +48,7 @@ class Policy(pydantic.BaseModel):
 
 
 class ServiceMeshConsumer(Object):
-    """Class for managing the consumer side of the service_mesh relation interface."""
+    """Class used for joining a service mesh."""
 
     def __init__(
         self,

--- a/lib/charms/istio_beacon_k8s/v0/service_mesh.py
+++ b/lib/charms/istio_beacon_k8s/v0/service_mesh.py
@@ -71,6 +71,7 @@ class Policy(pydantic.BaseModel):
 
     relation: str
     endpoints: List[Endpoint]
+    service: Optional[str]
 
 
 class ServiceMeshConsumer(Object):
@@ -133,6 +134,7 @@ class ServiceMeshConsumer(Object):
                             "app_name": relation.app.name,
                             "namespace": self._my_namespace(),
                             "endpoints": policy.endpoints,
+                            "service": policy.service,
                         }
                     )
         mesh_rel_data = {

--- a/lib/charms/istio_beacon_k8s/v0/service_mesh.py
+++ b/lib/charms/istio_beacon_k8s/v0/service_mesh.py
@@ -25,6 +25,7 @@ except ops.TooManyRelatedAppsError as e:
 ```
 """
 
+import enum
 import json
 import logging
 import re
@@ -37,14 +38,33 @@ LIBID = "3f40cb7e3569454a92ac2541c5ca0a0c"  # Never change this
 LIBAPI = 0
 LIBPATCH = 1
 
+PYDEPS = ["pydantic"]
+
 logger = logging.getLogger(__name__)
+
+
+class Method(str, enum.Enum):
+    """HTTP method."""
+
+    connect = "CONNECT"
+    delete = "DELETE"
+    get = "GET"
+    head = "HEAD"
+    options = "OPTIONS"
+    patch = "PATCH"
+    post = "POST"
+    put = "PUT"
+    trace = "TRACE"
 
 
 class Policy(pydantic.BaseModel):
     """Data type for holding a service mesh policy."""
 
     relation: str
-    endpoints: List[str]
+    hosts: List[str]
+    ports: List[int]
+    methods: List[Method]
+    paths: List[str]
 
 
 class ServiceMeshConsumer(Object):

--- a/lib/charms/istio_beacon_k8s/v0/service_mesh.py
+++ b/lib/charms/istio_beacon_k8s/v0/service_mesh.py
@@ -17,7 +17,18 @@ try:
     self._mesh = ServiceMeshConsumer(
         self,
         policies=[
-            Policy(relation="logging", endpoints=[f"*:{HTTP_LISTEN_PORT}"]),
+            Policy(
+                relation="logging",
+                endpoints=[
+                    Endpoint(
+                        hosts=[self._my_host_name],
+                        ports=[HTTP_LISTEN_PORT],
+                        methods=["GET"],
+                        paths=["/foo"],
+                    ),
+                ],
+                service=self._my_k8s_service(),
+            ),
         ],
     )
 except ops.TooManyRelatedAppsError as e:

--- a/lib/charms/istio_beacon_k8s/v0/service_mesh.py
+++ b/lib/charms/istio_beacon_k8s/v0/service_mesh.py
@@ -4,7 +4,7 @@
 """#Service Mesh Library.
 
 The service mesh library is used to facilitate adding your charmed application to a service mesh.
-The library leverages the `service_mesh` interface and the `cross_model_mesh` interface
+The library leverages the `service_mesh` and `cross_model_mesh` interfaces.
 
 To add service mesh support to your charm, instantiate a ServiceMeshConsumer object in the
 `__init__` method of your charm:

--- a/lib/charms/istio_beacon_k8s/v0/service_mesh.py
+++ b/lib/charms/istio_beacon_k8s/v0/service_mesh.py
@@ -10,7 +10,7 @@ To add service mesh support to your charm, instantiate a ServiceMeshConsumer obj
 `__init__` method of your charm:
 
 ```
-from charms.istio_beacon_k8s.v0.service_mesh import IsCrossModelError, Policy, ServiceMeshConsumer
+from charms.istio_beacon_k8s.v0.service_mesh import Policy, ServiceMeshConsumer
 
 ...
 self._mesh = ServiceMeshConsumer(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ extend-ignore = [
     "D408",
     "D409",
     "D413",
+    "N805",
 ]
 ignore = ["E501", "D107"]
 per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}

--- a/src/charm.py
+++ b/src/charm.py
@@ -35,8 +35,8 @@ class IstioBeaconCharm(ops.CharmBase):
         manifest.
         """
         for relation in self.model.relations["service-mesh"]:
+            logger.error(relation.data[relation.app])
             # Update the mesh
-            pass
         self.unit.status = ops.ActiveStatus()
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 [tox]
 no_package = True
 skip_missing_interpreters = True
-env_list = lint, static, unit, scenario
+env_list = lint, static-charm, static-lib, unit, scenario
 min_version = 4.0.0
 
 [vars]
@@ -68,6 +68,7 @@ commands =
 description = Run static type checks
 deps =
     pyright
+    lib: pydantic
     -r {tox_root}/requirements.txt
 commands =
     charm: pyright {posargs} {[vars]src_path}

--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,8 @@ min_version = 4.0.0
 [vars]
 src_path = {tox_root}/src
 tests_path = {tox_root}/tests
-;lib_path = {tox_root}/lib/charms/operator_name_with_underscores
-all_path = {[vars]src_path} {[vars]tests_path}
+lib_path = {tox_root}/lib/charms/istio_beacon_k8s
+all_path = {[vars]src_path} {[vars]tests_path} {[vars]lib_path}
 
 [testenv]
 set_env =
@@ -27,10 +27,8 @@ pass_env =
 description = Apply coding style standards to code
 deps =
     black
-    ruff
 commands =
     black {[vars]all_path}
-    ruff check --fix {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
@@ -75,7 +73,7 @@ deps =
     -r {tox_root}/requirements.txt
 commands =
     charm: pyright {posargs} {[vars]src_path}
-    lib:
+    lib: pyright {posargs} {[vars]lib_path}
 
 [testenv:integration]
 description = Run integration tests

--- a/tox.ini
+++ b/tox.ini
@@ -37,10 +37,8 @@ deps =
     ruff
     codespell
 commands =
-    # if this charm owns a lib, uncomment "lib_path" variable
-    # and uncomment the following line
-    # codespell {[vars]lib_path}
-    codespell {tox_root}
+    codespell {[vars]src_path}
+    codespell {[vars]lib_path}
     ruff check {[vars]all_path}
     black --check --diff {[vars]all_path}
 


### PR DESCRIPTION
## Issue
Create the service_mesh library

In scope for this PR: Using the constructor and relations to generate the relation data required to allow a service mesh to generate access policies. Adding apps to the mesh that relate over `service_mesh`.

In scope for the next PR: Add the cross_model_mesh interface support to allow for cross model relations.

Unrelated to the lib: Everything else. (model join for example has nothing to do with relations).