### PR TITLE
feat: add 'hardened' config value

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -70,6 +70,12 @@ config:
       description: >
         Add this charm's model to the service mesh. 
         All charms in this model will automatically be added to the mesh.
+    hardened:
+      type: boolean
+      default: false
+      description: >
+        If True, the charm will create AuthorizationPolicies for all applications that request them on the service-mesh
+        relation.  Otherwise, no AuthorizationPolicies will be created.
 
 resources:
   metrics-proxy-image:

--- a/src/charm.py
+++ b/src/charm.py
@@ -219,6 +219,10 @@ class IstioBeaconCharm(ops.CharmBase):
 
     def _build_authorization_policies(self, mesh_info):
         """Build authorization policies for all related applications."""
+        if self.config["hardened"] is False:
+            logger.info("Hardened mode is disabled. Skipping AuthorizationPolicy creation.")
+            return []
+
         authorization_policies = [None] * len(mesh_info)
         for i, policy in enumerate(mesh_info):
             target_service = policy.target_service or policy.target_app_name

--- a/tox.ini
+++ b/tox.ini
@@ -28,8 +28,8 @@ description = Apply coding style standards to code
 deps =
     ruff
 commands =
-    ruff check --fix {[vars]all_path}
-    ruff format {[vars]all_path}
+    ruff check --fix {[vars]all_path} --exclude "tests/integration/testers/*/lib"
+    ruff format {[vars]all_path} --exclude "tests/integration/testers/*/lib"
 
 [testenv:lint]
 description = Check code against coding style standards
@@ -39,8 +39,8 @@ deps =
     ruff
 commands =
     codespell {[vars]all_path}
-    ruff check {[vars]all_path}
-    ruff format --check {[vars]all_path}
+    ruff check {[vars]all_path} --exclude "tests/integration/testers/*/lib"
+    ruff format --check {[vars]all_path} --exclude "tests/integration/testers/*/lib"
 
 [testenv:unit]
 description = Run unit tests


### PR DESCRIPTION
This adds a config value 'hardened' which, when enabled, means the charm will create AuthorizationPolicies for any related application that requests them via the service-mesh relation
