### PR TITLE
feat: add config to control if Authorization Policies are generated

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -56,6 +56,19 @@ parts:
 
 config:
   options:
+    manage-authorization-policies:
+      type: boolean
+      default: true
+      description: >
+        Automatically create Istio authorization policies for any charm requiresting them over the service mesh 
+        relation.  If set to false, the charm will not create any authorization policies, but will still do other 
+        functions like provide a waypoint.
+    model-on-mesh:
+      type: boolean
+      default: false
+      description: >
+        Add this charm's model to the service mesh. 
+        All charms in this model will automatically be added to the mesh.
     ready-timeout:
       type: int
       default: 100
@@ -64,12 +77,6 @@ config:
         ready. This applies specifically to the deployment created for the Istio 
         waypoint controller. If the deployment does not become ready within this time, 
         charm will go into error state.
-    model-on-mesh:
-      type: boolean
-      default: false
-      description: >
-        Add this charm's model to the service mesh. 
-        All charms in this model will automatically be added to the mesh.
 
 resources:
   metrics-proxy-image:

--- a/src/charm.py
+++ b/src/charm.py
@@ -308,9 +308,17 @@ class IstioBeaconCharm(ops.CharmBase):
     def _sync_authorization_policies(self):
         """Sync authorization policies."""
         krm = self._get_authorization_policy_resource_manager()
-        authorization_policies = self._build_authorization_policies(self._mesh.mesh_info())
-        logger.debug("Reconciling state of AuthorizationPolicies to:")
-        logger.debug(authorization_policies)
+        if self.config["manage-authorization-policies"]:
+            authorization_policies = self._build_authorization_policies(self._mesh.mesh_info())
+            logger.debug("Reconciling state of AuthorizationPolicies to:")
+            logger.debug(authorization_policies)
+        else:
+            # We reconcile to an empty list rather than skip reconciling entirely so that, if the user changes the
+            # config while the charm is running, we remove all AuthorizationPolicies.
+            logger.debug(
+                "AuthorizationPolicies creation is disabled - reconciling to no Authorization Policies."
+            )
+            authorization_policies = []
         krm.reconcile(authorization_policies)  # type: ignore
 
     def _sync_waypoint_resources(self):


### PR DESCRIPTION
## Issue

Previously, all applications requesting Authorization Policies via the service-mesh relation would receive those policies.  Because the presence of any Authorization Policy for a target results in all traffic to that target requiring an Authorization Policy, this could have a detrimental effect on an environment where not all traffic is being described by Authorization Policies.

## Solution
To mitigate this, this commit adds a toggle for Authorization Policy generation, leaving that feature on by default.  If disabled, Authorization Policies will not be created for any related application, even if they define Policies in their service-mesh relation data.

## Context
-

## Testing Instructions
Unit tests cover this change.

To manually test, do:
```
tox -e integration -- --keep-models

# confirm authorization policy exists
kubectl get authorizationpolicies.security.istio.io -A
# should have 1 AP

# update config to disable AP generation
juju config istio-beacon-k8s create-authorization-policies=false

kubectl get authorizationpolicies.security.istio.io -A
# should have 0 APs
```

## Upgrade Notes
-