### PR TITLE
Modeloperator traffic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__/
 *.py[cod]
 .idea
 .vscode/
+tests/integration/testers/service-mesh-tester/lib/*

--- a/src/charm.py
+++ b/src/charm.py
@@ -298,7 +298,7 @@ class IstioBeaconCharm(ops.CharmBase):
         # We need to allow the juju controller to be able to talk to the model operator
         if self.config["model-on-mesh"]:
             authorization_policies.append(
-                    RESOURCE_TYPES["AuthorizationPolicy"](  # type: ignore
+                RESOURCE_TYPES["AuthorizationPolicy"](  # type: ignore
                     metadata=ObjectMeta(
                         name=f"allow-traffic-to-{self.model.name}-modeloperator",
                         namespace=self.model.name,

--- a/src/charm.py
+++ b/src/charm.py
@@ -236,7 +236,7 @@ class IstioBeaconCharm(ops.CharmBase):
         self.unit.status = ActiveStatus()
 
     def _build_authorization_policies(self, mesh_info: List[MeshPolicy]):
-        """Build authorization policies for all related applications."""
+        """Build all managed authorization policies."""
         authorization_policies = [None] * len(mesh_info)
         for i, policy in enumerate(mesh_info):
             target_service = policy.target_service or policy.target_app_name

--- a/src/charm.py
+++ b/src/charm.py
@@ -300,7 +300,7 @@ class IstioBeaconCharm(ops.CharmBase):
             authorization_policies.append(
                 RESOURCE_TYPES["AuthorizationPolicy"](  # type: ignore
                     metadata=ObjectMeta(
-                        name=f"allow-traffic-to-{self.model.name}-modeloperator",
+                        name=f"{self.app.name}-{self.model.name}-policy-all-sources-modeloperator",
                         namespace=self.model.name,
                     ),
                     spec=AuthorizationPolicySpec(

--- a/src/charm.py
+++ b/src/charm.py
@@ -39,6 +39,7 @@ from models import (
     Rule,
     Source,
     To,
+    WorkloadSelector,
 )
 
 logger = logging.getLogger(__name__)
@@ -293,6 +294,24 @@ class IstioBeaconCharm(ops.CharmBase):
                     # exclude_none=True because null values in this data always mean the Kubernetes default
                 ).model_dump(by_alias=True, exclude_unset=True, exclude_none=True),
             )
+
+        # We need to allow the juju controller to be able to talk to the model operator
+        if self.config["model-on-mesh"]:
+            authorization_policies.append(
+                    RESOURCE_TYPES["AuthorizationPolicy"](  # type: ignore
+                    metadata=ObjectMeta(
+                        name=f"allow-traffic-to-{self.model.name}-modeloperator",
+                        namespace=self.model.name,
+                    ),
+                    spec=AuthorizationPolicySpec(
+                        selector=WorkloadSelector(
+                            matchLabels={"operator.juju.is/name": "modeloperator"}
+                        ),
+                        rules=[Rule()],
+                    ).model_dump(by_alias=True, exclude_unset=True, exclude_none=True),
+                )
+            )
+
         return authorization_policies
 
     def _construct_waypoint(self):

--- a/src/models.py
+++ b/src/models.py
@@ -70,7 +70,7 @@ class PolicyTargetReference(BaseModel):
 
 
 class WorkloadSelector(BaseModel):
-    """WorkloadSelector defines the selector for the policy."""
+    """WorkloadSelector defines the target of the policy for ztunnel bound policies."""
 
     matchLabels: Dict[str, str]
 

--- a/src/models.py
+++ b/src/models.py
@@ -136,9 +136,7 @@ class AuthorizationPolicySpec(BaseModel):
 
     @model_validator(mode="after")
     def validate_target(self):
-        """Validate that exactly one of targetRefs and selector is defined."""
-        if (self.targetRefs is None and self.selector is None) or (
-            self.targetRefs is not None and self.selector is not None
-        ):
-            raise ValueError("Only one of targetRefs and selector can be set")
+        """Validate that at most one of targetRefs and selector is defined."""
+        if self.targetRefs is not None and self.selector is not None:
+            raise ValueError("At most one of targetRefs and selector can be set")
         return self

--- a/src/models.py
+++ b/src/models.py
@@ -8,7 +8,7 @@ from enum import Enum
 from typing import Dict, List, Optional
 
 from charms.istio_beacon_k8s.v0.service_mesh import Method
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 # Global metadata schema
@@ -61,7 +61,7 @@ class Action(str, Enum):
 
 
 class PolicyTargetReference(BaseModel):
-    """PolicyTargetReference defines the target of the policy."""
+    """PolicyTargetReference defines the target of the policy for waypoint bound policies."""
 
     group: str
     kind: str
@@ -130,8 +130,15 @@ class AuthorizationPolicySpec(BaseModel):
     """AuthorizationPolicyResource defines the structure of an Istio AuthorizationPolicy Kubernetes resource."""
 
     action: Action = Action.allow
-    targetRefs: List[PolicyTargetReference]
+    targetRefs: Optional[List[PolicyTargetReference]] = Field(default=None)
+    selector: Optional[WorkloadSelector] = Field(default=None)
     rules: List[Rule]
-    # Not implemented, but it exists
-    # selector: WorkloadSelector
-    # provider
+
+    @model_validator(mode="after")
+    def validate_target(self):
+        """Validate that exactly one of targetRefs and selector is defined."""
+        if (self.targetRefs is None and self.selector is None) or (
+            self.targetRefs is not None and self.selector is not None
+        ):
+            raise ValueError("Only one of targetRefs and selector can be set")
+        return self

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -4,8 +4,13 @@
 # See LICENSE file for licensing details.
 
 from lightkube.core.client import Client
+from lightkube.generic_resource import create_namespaced_resource
 from lightkube.resources.core_v1 import Namespace
 from pytest_operator.plugin import OpsTest
+
+AuthPolicy = create_namespaced_resource(
+    "security.istio.io", "v1", "AuthorizationPolicy", "authorizationpolicies"
+)
 
 
 async def validate_labels(ops_test: OpsTest, app_name: str, should_be_present: bool):
@@ -27,3 +32,8 @@ async def validate_labels(ops_test: OpsTest, app_name: str, should_be_present: b
             assert actual_value == expected_value, f"Label {label} is missing or incorrect."
         else:
             assert actual_value is None, f"Label {label} should have been removed."
+
+
+def validate_policy_exists(ops_test: OpsTest, policy_name: str):
+    client = Client()
+    client.get(AuthPolicy, policy_name, namespace=ops_test.model.name)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -71,7 +71,9 @@ async def test_mesh_config(ops_test: OpsTest):
         [APP_NAME], status="active", timeout=1000, raise_on_error=False
     )
     await validate_labels(ops_test, APP_NAME, should_be_present=True)
-    validate_policy_exists(ops_test, f"{APP_NAME}-{ops_test.model.name}-policy-all-sources-modeloperator")
+    validate_policy_exists(
+        ops_test, f"{APP_NAME}-{ops_test.model.name}-policy-all-sources-modeloperator"
+    )
 
     await ops_test.model.applications[APP_NAME].set_config({"model-on-mesh": "false"})
     await ops_test.model.wait_for_idle(
@@ -79,7 +81,9 @@ async def test_mesh_config(ops_test: OpsTest):
     )
     await validate_labels(ops_test, APP_NAME, should_be_present=False)
     with pytest.raises(httpx.HTTPStatusError):
-        validate_policy_exists(ops_test, f"{APP_NAME}-{ops_test.model.name}-policy-all-sources-modeloperator")
+        validate_policy_exists(
+            ops_test, f"{APP_NAME}-{ops_test.model.name}-policy-all-sources-modeloperator"
+        )
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -9,10 +9,11 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Optional
 
+import httpx
 import pytest
 import sh
 import yaml
-from helpers import validate_labels
+from helpers import validate_labels, validate_policy_exists
 from pytest_operator.plugin import OpsTest
 from tenacity import (
     retry,
@@ -70,12 +71,15 @@ async def test_mesh_config(ops_test: OpsTest):
         [APP_NAME], status="active", timeout=1000, raise_on_error=False
     )
     await validate_labels(ops_test, APP_NAME, should_be_present=True)
+    validate_policy_exists(ops_test, f"allow-traffic-to-{ops_test.model.name}-modeloperator")
 
     await ops_test.model.applications[APP_NAME].set_config({"model-on-mesh": "false"})
     await ops_test.model.wait_for_idle(
         [APP_NAME], status="active", timeout=1000, raise_on_error=False
     )
     await validate_labels(ops_test, APP_NAME, should_be_present=False)
+    with pytest.raises(httpx.HTTPStatusError):
+        validate_policy_exists(ops_test, f"allow-traffic-to-{ops_test.model.name}-modeloperator")
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -71,7 +71,7 @@ async def test_mesh_config(ops_test: OpsTest):
         [APP_NAME], status="active", timeout=1000, raise_on_error=False
     )
     await validate_labels(ops_test, APP_NAME, should_be_present=True)
-    validate_policy_exists(ops_test, f"allow-traffic-to-{ops_test.model.name}-modeloperator")
+    validate_policy_exists(ops_test, f"{APP_NAME}-{ops_test.model.name}-policy-all-sources-modeloperator")
 
     await ops_test.model.applications[APP_NAME].set_config({"model-on-mesh": "false"})
     await ops_test.model.wait_for_idle(

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -164,6 +164,6 @@ def assert_request_returns_http_code(
         f"Got {returned_code} for {source_unit} -> {target_url} on {method} - expected {code}"
     )
 
-    assert (
-        returned_code == code
-    ), f"Expected {code} but got {returned_code} for {source_unit} -> {target_url} on {method}"
+    assert returned_code == code, (
+        f"Expected {code} but got {returned_code} for {source_unit} -> {target_url} on {method}"
+    )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -47,7 +47,7 @@ ISTIO_K8S = CharmDeploymentConfiguration(
 @pytest.mark.abort_on_fail
 async def test_deploy_dependencies(ops_test: OpsTest):
     # Not the model name just an alias
-    await ops_test.track_model("istio-system")
+    await ops_test.track_model("istio-system", model_name=f"{ops_test.model.name}-istio-system")
     istio_system_model = ops_test.models.get("istio-system")
 
     await istio_system_model.model.deploy(**asdict(ISTIO_K8S))
@@ -142,7 +142,9 @@ async def test_service_mesh_relation(ops_test: OpsTest, service_mesh_tester):
 async def test_modeloperator_rule(ops_test: OpsTest, service_mesh_tester):
     # Ensure model is on mesh
     await ops_test.model.applications[APP_NAME].set_config({"model-on-mesh": "true"})
-    await ops_test.track_model("off-mesh-model", model_name=f"{ops_test.model.name}-off-mesh-model")
+    await ops_test.track_model(
+        "off-mesh-model", model_name=f"{ops_test.model.name}-off-mesh-model"
+    )
     omm = ops_test.models.get("off-mesh-model")
     resources = {"echo-server-image": "jmalloc/echo-server:v0.3.7"}
     await omm.model.deploy(

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -142,7 +142,7 @@ async def test_service_mesh_relation(ops_test: OpsTest, service_mesh_tester):
 async def test_modeloperator_rule(ops_test: OpsTest, service_mesh_tester):
     # Ensure model is on mesh
     await ops_test.model.applications[APP_NAME].set_config({"model-on-mesh": "true"})
-    await ops_test.track_model("off-mesh-model")
+    await ops_test.track_model("off-mesh-model", model_name=f"{ops_test.model.name}-off-mesh-model")
     omm = ops_test.models.get("off-mesh-model")
     resources = {"echo-server-image": "jmalloc/echo-server:v0.3.7"}
     await omm.model.deploy(

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -79,7 +79,7 @@ async def test_mesh_config(ops_test: OpsTest):
     )
     await validate_labels(ops_test, APP_NAME, should_be_present=False)
     with pytest.raises(httpx.HTTPStatusError):
-        validate_policy_exists(ops_test, f"allow-traffic-to-{ops_test.model.name}-modeloperator")
+        validate_policy_exists(ops_test, f"{APP_NAME}-{ops_test.model.name}-policy-all-sources-modeloperator")
 
 
 @pytest.mark.abort_on_fail

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ src_path = {tox_root}/src
 tests_path = {tox_root}/tests
 lib_path = {tox_root}/lib/charms/istio_beacon_k8s
 all_path = {[vars]src_path} {[vars]tests_path} {[vars]lib_path}
+tester_lib_path = {tox_root}/tests/integration/testers/service-mesh-tester/lib
 
 [testenv]
 set_env =
@@ -28,7 +29,7 @@ description = Apply coding style standards to code
 deps =
     ruff
 commands =
-    ruff check --fix {[vars]all_path}
+    ruff check --fix {[vars]all_path} --exclude {[vars]tester_lib_path}
     ruff format {[vars]all_path}
 
 [testenv:lint]
@@ -39,7 +40,7 @@ deps =
     ruff
 commands =
     codespell {[vars]all_path}
-    ruff check {[vars]all_path}
+    ruff check {[vars]all_path} --exclude {[vars]tester_lib_path}
     ruff format --check {[vars]all_path}
 
 [testenv:unit]

--- a/tox.ini
+++ b/tox.ini
@@ -86,6 +86,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
+    httpx
     pytest
     juju
     pytest-operator


### PR DESCRIPTION
## Issue
Fixes #39


## Solution
When `model-on-mesh` is enabled, create an `AuthorizationPolicy` to allow traffic to the modeloperator.


## Testing Instructions
* Deploy istio-k8s and istio-beacon-k8s
* set model-on-mesh=true
* check authorization policies
* observe ztunnel logs have no errors


## Upgrade Notes
Fixed an issue where the juju controller could not reach the modeloperator when model-on-mesh was enabled.
