### PR TITLE
fix: correctly scope AuthorizationPolicy for modeloperator

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -304,7 +304,7 @@ class IstioBeaconCharm(ops.CharmBase):
                     ),
                     spec=AuthorizationPolicySpec(
                         selector=WorkloadSelector(
-                            matchLabels={"operator.juju.is/name": "modeloperator"}
+                            matchLabels={"juju-modeloperator": "modeloperator"}
                         ),
                         rules=[Rule()],
                     ).model_dump(by_alias=True, exclude_unset=True, exclude_none=True),


### PR DESCRIPTION
## Issue
Fixes #78

## Solution
Updates the label used to scope the AuthorizationPolicy for the modeloperator in beacon's namespace to match the current Juju naming convention.

An alternate approach here could have been to create an AP for both the old and new schema, or maybe detecting which is appropriate.  We can do that, but since we require Juju 3.6 before this goes stable and all the 3.6's will follow this schema, that feels unnecessary(?).

## Context
#78

## Testing Instructions
`test_modeloperator_rule` integration test covers this

## Upgrade Notes
None