### PR TITLE
refactor: expose the service mesh library's charm resource labelling logic

### DIFF
--- a/tests/unit/test_authorization_policies.py
+++ b/tests/unit/test_authorization_policies.py
@@ -143,7 +143,6 @@ def test_charm_creates_authorization_policies_on_relation_changed(
     istio_beacon_charm,
     istio_beacon_context,
     service_mesh_relation,
-    mock_lightkube_client,
 ):
     """Test that the charm config create_authorization_policies controls whether AuthorizationPolicies are created."""
     istio_beacon_context.run(

--- a/tests/unit/test_mesh_consumer.py
+++ b/tests/unit/test_mesh_consumer.py
@@ -3,14 +3,20 @@
 
 import json
 import typing
+from unittest.mock import MagicMock, patch
 
 import pytest
 import scenario
-from charms.istio_beacon_k8s.v0.service_mesh import Endpoint, Policy, ServiceMeshConsumer
+from charms.istio_beacon_k8s.v0.service_mesh import (
+    Endpoint,
+    Policy,
+    ServiceMeshConsumer,
+    reconcile_charm_labels,
+)
 from ops import CharmBase
 
 
-def consumer_context(policies: typing.List[Policy]):
+def consumer_context(policies: typing.List[Policy]) -> scenario.Context:
     meta = {
         "name": "consumer-charm",
         "requires": {
@@ -230,3 +236,152 @@ def test_relation_data_policies(policies, expected_data):
     assert (
         json.loads(out.get_relation(mesh_relation.id).local_app_data["policies"]) == expected_data
     )
+
+
+def lightkube_client_mock(unmanaged_labels: dict, managed_labels: dict) -> MagicMock:
+    """Return a mock lightkube client that has a StatefulSet, Service, and ConfigMap, each with the given labels.
+
+    This simulates the kubernetes resources that a charm would have and the service mesh library would interact with.
+    All resources are mocked using a shallow copy of the input labels.
+
+    The returned mock has a `.get()` that will return the StatefulSet, Service, or ConfigMap as required.  If called
+    for anything else, it will raise a KeyError.
+
+    Args:
+        unmanaged_labels (dict): Labels that are currently on the objects and are not managed by reconcile_charm_labels.
+                                 For example, a label an admin added to the Service manually.
+        managed_labels (dict): Labels that are currently on the objects and are managed by reconcile_charm_labels.
+    """
+    client = MagicMock()
+
+    obj_labels = unmanaged_labels.copy()
+    obj_labels.update(managed_labels)
+
+    # Mock StatefulSet that will create Pods with the labels
+    # Pods and Service get both the managed and unmanaged labels
+    stateful_set = MagicMock()
+    # Use a copy here, otherwise all mocks point at a shared obj_labels
+    stateful_set.spec.template.metadata.labels = obj_labels.copy()
+
+    # Mock Service that has the labels
+    service = MagicMock()
+    service.metadata.labels = obj_labels.copy()
+
+    # Mock ConfigMap with a labels field in data
+    config_map = MagicMock()
+    # ConfigMap is a memory of what labels are currently managed.
+    config_map.data = {"labels": json.dumps(managed_labels)}
+
+    client.get.side_effect = lambda res, name: {
+        "StatefulSet": stateful_set,
+        "Service": service,
+        "ConfigMap": config_map,
+    }[res.__name__]
+
+    return client
+
+
+def assert_charm_kubernetes_objects_have_labels(expected_patch, expected_in_configmap, mock_client: MagicMock):
+    """Assert that the mock client has patched the StatefulSet, Service, and ConfigMap as expected.
+
+    Args:
+        expected_patch (dict): The labels that should be present on the StatefulSet and Service after patching.
+        expected_in_configmap (dict): The labels that should be present in the ConfigMap's data field under "labels".
+        mock_client (MagicMock): The mock lightkube client that was used to patch the resources.
+    """
+    # Ensure the patched resources have the expected labels
+    patched_statefulset = [call_args.kwargs['obj'] for call_args in mock_client.patch.call_args_list if
+                           call_args.kwargs['res'].__name__ == "StatefulSet"]
+    assert len(patched_statefulset) == 1
+    assert patched_statefulset[0].spec.template.metadata.labels == expected_patch
+    patched_service = [call_args.kwargs['obj'] for call_args in mock_client.patch.call_args_list if
+                       call_args.kwargs['res'].__name__ == "Service"]
+    assert len(patched_service) == 1
+    assert patched_service[0].metadata.labels == expected_patch
+    patched_configmap = [call_args.kwargs['obj'] for call_args in mock_client.patch.call_args_list if
+                         call_args.kwargs['res'].__name__ == "ConfigMap"]
+    assert len(patched_configmap) == 1
+    assert len(patched_configmap[0].data) == 1
+    assert json.loads(patched_configmap[0].data["labels"]) == expected_in_configmap
+
+
+@pytest.mark.parametrize(
+    "initial_unmanaged_labels, initial_managed_labels, desired_managed_labels, expected_patch",
+    [
+        # Add label to objects, without disrupting existing labels
+        (
+            {"some-unmanaged-label": "some-value"},
+            {},
+            {"key-added": "value-added"},
+            {"key-added": "value-added", "some-unmanaged-label": "some-value"},
+        ),
+        # Add one label, update one label, and remove one label without disrupting existing labels
+        (
+            {"some-unmanaged-label": "some-value"},
+            {"key-to-be-removed": "value-to-be-removed", "key-to-be-updated": "value-to-be-updated"},
+            {"key-to-be-updated": "value-updated", "key-added": "value-added"},
+            {"key-to-be-removed": None, "key-to-be-updated": "value-updated", "key-added": "value-added", "some-unmanaged-label": "some-value"}
+        ),
+        # Remove labels
+        (
+            {"some-unmanaged-label": "some-value"},
+            {"key-to-be-removed": "v", "key-to-be-removed2": "v"},
+            {},
+            {"key-to-be-removed": None, "key-to-be-removed2": None, "some-unmanaged-label": "some-value"},
+        ),
+
+    ]
+)
+def test_reconcile_charm_labels(
+        initial_unmanaged_labels,
+        initial_managed_labels,
+        desired_managed_labels,
+        expected_patch
+):
+    """Test that reconcile_charm_labels correctly patches the StatefulSet, Service, and ConfigMap with the labels.
+
+    Args:
+        initial_unmanaged_labels (dict): Labels that are currently on the objects and are not managed by
+                                         reconcile_charm_labels.
+        initial_managed_labels (dict): Labels on the kubernetes objects before execution
+        desired_managed_labels (dict): The labels that should be present after execution.
+        expected_patch (dict): The labels our client.patch() should send to Kubernetes
+    """
+    mock_client = lightkube_client_mock(unmanaged_labels=initial_unmanaged_labels, managed_labels=initial_managed_labels)
+
+    reconcile_charm_labels(
+        client=mock_client,
+        app_name="my-app",
+        namespace="test-ns",
+        label_configmap_name="my-cm",
+        labels=desired_managed_labels.copy(),
+    )
+
+    assert_charm_kubernetes_objects_have_labels(expected_patch=expected_patch, expected_in_configmap=desired_managed_labels, mock_client=mock_client)
+
+
+def test_reconcile_charm_labels_configmap_created_on_404():
+    """Test that reconcile_charm_labels creates its ConfigMap if it doesn't exist."""
+    mocked_client = lightkube_client_mock(unmanaged_labels={}, managed_labels={})
+    def side_effect(res, name):
+        if res.__name__ == "ConfigMap":
+            from httpx import HTTPStatusError, Request, Response
+            raise HTTPStatusError("Not found", request=Request("GET", "url"), response=Response(404))
+        else:
+            return MagicMock()
+    mocked_client.get.side_effect = side_effect
+
+    # mock _init_label_configmap to return a mock ConfigMap with a data field that has no labels included, just so
+    # reconcile_charm_labels doesn't fail
+    with patch("charms.istio_beacon_k8s.v0.service_mesh._init_label_configmap") as mock_init:
+        mock_init.return_value = MagicMock()
+        mock_init.return_value.data = {"labels": "{}"}
+        reconcile_charm_labels(
+            client=mocked_client,
+            app_name="my-app",
+            namespace="test-ns",
+            label_configmap_name="my-cm",
+            labels={},
+        )
+        # Ensure the ConfigMap was created
+        mock_init.assert_called_once()


### PR DESCRIPTION
## Issue

This is a stepping stone to allow istio-beacon to put itself on the service mesh.

The ServiceMeshConsumer can add labels to a Charm's Kubernetes resources (which we use to put those resources on the mesh).  This is the same capability we want for the istio-beacon charm, but previously this logic was embedded in the ServiceMeshConsumer and not easily accessible outside the class.

## Solution

This refactors the ServiceMeshConsumer to make the charm labelling logic accessible outside the class.  This will make it trivial to also put the istio-beacon charm on the mesh via the same means.

## Context

Contributes to #41 

## Testing Instructions

Covered by CI and new unit tests


## Upgrade Notes
None