### PR TITLE
fix: scale beacon without going into Blocked state

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -51,6 +51,10 @@ requires:
       Endpoint for integrating over a `tracing` interface and sending charm traces 
       to a distributed tracing backend such as Tempo.
 
+peers:
+  peers:
+    interface: istio_beacon_k8s_peers
+
 config:
   options:
     manage-authorization-policies:

--- a/lib/charms/istio_beacon_k8s/v0/service_mesh.py
+++ b/lib/charms/istio_beacon_k8s/v0/service_mesh.py
@@ -159,7 +159,7 @@ from ops import CharmBase, Object, RelationMapping
 
 LIBID = "3f40cb7e3569454a92ac2541c5ca0a0c"  # Never change this
 LIBAPI = 0
-LIBPATCH = 5
+LIBPATCH = 6
 
 PYDEPS = ["lightkube", "pydantic"]
 
@@ -392,9 +392,11 @@ class ServiceMeshProvider(Object):
 
     def update_relations(self):
         """Update all relations with the labels needed to use the mesh."""
-        rel_data = json.dumps(self._labels)
-        for relation in self._charm.model.relations[self._relation_name]:
-            relation.data[self._charm.app]["labels"] = rel_data
+        # Only the leader unit can update the application data bag
+        if self._charm.unit.is_leader():
+            rel_data = json.dumps(self._labels)
+            for relation in self._charm.model.relations[self._relation_name]:
+                relation.data[self._charm.app]["labels"] = rel_data
 
     def mesh_info(self) -> List[MeshPolicy]:
         """Return the relation data that defines Policies requested by the related applications."""

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -5,12 +5,12 @@
 
 import logging
 from dataclasses import asdict
-from pathlib import Path
 
 import httpx
 import pytest
-import yaml
 from helpers import (
+    APP_NAME,
+    RESOURCES,
     assert_request_returns_http_code,
     istio_k8s,
     validate_labels,
@@ -21,12 +21,6 @@ from lightkube.resources.core_v1 import Pod
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
-
-METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
-APP_NAME = METADATA["name"]
-RESOURCES = {
-    "metrics-proxy-image": METADATA["resources"]["metrics-proxy-image"]["upstream-source"],
-}
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_charm_scaling.py
+++ b/tests/integration/test_charm_scaling.py
@@ -1,0 +1,129 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import logging
+from dataclasses import asdict
+
+import pytest
+from charmed_service_mesh_helpers import charm_kubernetes_label
+from helpers import (
+    APP_NAME,
+    RESOURCES,
+    get_hpa,
+    istio_k8s,
+)
+from pytest_operator.plugin import OpsTest
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.abort_on_fail
+async def test_deploy_dependencies(ops_test: OpsTest):
+    assert ops_test.model
+    # Not the model name just an alias
+    await ops_test.track_model(
+        "istio-system",
+        model_name=f"{ops_test.model.name}-istio-system"
+    )
+    istio_system_model = ops_test.models.get("istio-system")
+    assert istio_system_model
+
+    await istio_system_model.model.deploy(**asdict(istio_k8s))
+    await istio_system_model.model.wait_for_idle(
+        [istio_k8s.application_name], status="active", timeout=1000
+    )
+
+
+@pytest.mark.abort_on_fail
+async def test_deployment(ops_test: OpsTest, istio_beacon_charm):
+    assert ops_test.model
+    await ops_test.model.deploy(
+        istio_beacon_charm,
+        resources=RESOURCES,
+        application_name=APP_NAME,
+        trust=True,
+    )
+    await ops_test.model.wait_for_idle(
+        [APP_NAME],
+        status="active",
+        timeout=1000,
+        raise_on_error=False,
+    )
+
+
+@pytest.mark.abort_on_fail
+async def test_service_mesh_relation(ops_test: OpsTest, service_mesh_tester):
+    """Adds a tester charm and creates a service mesh relation between beacon and the tester charm.
+
+    The subsequent scaling test makes sure that the scaling up/down happens successfully with the service mesh relation in place.
+    """
+    assert ops_test.model
+    resources = {"echo-server-image": "jmalloc/echo-server:v0.3.7"}
+    await ops_test.model.deploy(
+        service_mesh_tester,
+        application_name="tester",
+        resources=resources,
+        trust=True,
+    )
+    await ops_test.model.wait_for_idle(
+        ["tester"],
+        status="active",
+        timeout=1000,
+    )
+    await ops_test.model.add_relation("tester:service-mesh", APP_NAME)
+
+
+@pytest.mark.abort_on_fail
+@pytest.mark.parametrize(
+    "n_units",
+    (
+        # Scale up from 1 to 3
+        3,
+        # Scale down to 2
+        2,
+    ),
+)
+async def test_waypoint_scaling(ops_test: OpsTest, n_units):
+    """Tests that, when the application is scaled, the HPA managing replicas on the Waypoint is scaled too.
+
+    This test also makes sure that the scaling does not affect any existing service mesh relation.s
+    Note: This test is stateful and will leave the deployment at a scale of 2.
+    """
+    assert ops_test.model
+    await ops_test.model.applications[APP_NAME].scale(n_units)
+    await ops_test.model.wait_for_idle(
+        [APP_NAME],
+        status="active",
+        timeout=2000,
+        raise_on_error=False,
+    )
+
+    waypoint_name = charm_kubernetes_label(
+        model_name=ops_test.model.name,
+        app_name=APP_NAME,
+        suffix="-waypoint",
+        separator="-",
+        max_length=63
+    )
+    waypoint_hpa = await get_hpa(ops_test.model.name, waypoint_name)
+    assert waypoint_hpa is not None
+    assert waypoint_hpa.spec.minReplicas == n_units  # pyright: ignore[reportOptionalMemberAccess]
+    assert waypoint_hpa.spec.maxReplicas == n_units  # pyright: ignore[reportOptionalMemberAccess]
+
+    assert await wait_for_hpa_current_replicas(
+        ops_test.model.name, waypoint_name, n_units
+    ), f"Expected currentReplicas to be {n_units}, got {waypoint_hpa.status.currentReplicas}"  # pyright: ignore[reportOptionalMemberAccess]
+
+
+@pytest.mark.abort_on_fail
+async def wait_for_hpa_current_replicas(
+    namespace, hpa_name, expected_replicas, retries=10, delay=10
+):
+    for _ in range(retries):
+        # freshly grab the hpa, but no need to assert its existence as that should be checked by the caller of this method
+        waypoint_hpa = await get_hpa(namespace, hpa_name)
+        if waypoint_hpa.status.currentReplicas == expected_replicas:  # pyright: ignore[reportOptionalMemberAccess]
+            return True
+        await asyncio.sleep(delay)
+    return False

--- a/tests/integration/test_cross_model.py
+++ b/tests/integration/test_cross_model.py
@@ -6,20 +6,17 @@
 """Tests that istio-beacon creates AuthorizationPolicies that enable traffic for charms related cross-model."""
 
 from dataclasses import asdict
-from pathlib import Path
 
 import pytest
-import yaml
-from helpers import assert_request_returns_http_code, istio_k8s
+from helpers import (
+    APP_NAME,
+    RECEIVER,
+    RESOURCES,
+    SENDER,
+    assert_request_returns_http_code,
+    istio_k8s,
+)
 from pytest_operator.plugin import ModelState, OpsTest
-
-METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
-APP_NAME = METADATA["name"]
-SENDER = "sender"
-RECEIVER = "receiver"
-RESOURCES = {
-    "metrics-proxy-image": METADATA["resources"]["metrics-proxy-image"]["upstream-source"],
-}
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_service_mesh_cross_model.py
+++ b/tests/integration/test_service_mesh_cross_model.py
@@ -6,20 +6,17 @@
 """Tests that istio-beacon creates AuthorizationPolicies that enable traffic for charms related cross-model."""
 
 from dataclasses import asdict
-from pathlib import Path
 
 import pytest
-import yaml
-from helpers import assert_request_returns_http_code, istio_k8s
+from helpers import (
+    APP_NAME,
+    RECEIVER,
+    RESOURCES,
+    SENDER,
+    assert_request_returns_http_code,
+    istio_k8s,
+)
 from pytest_operator.plugin import ModelState, OpsTest
-
-METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
-APP_NAME = METADATA["name"]
-SENDER = "sender"
-RECEIVER = "receiver"
-RESOURCES = {
-    "metrics-proxy-image": METADATA["resources"]["metrics-proxy-image"]["upstream-source"],
-}
 
 
 @pytest.fixture(scope="module")

--- a/tests/unit/test_charm_scenario.py
+++ b/tests/unit/test_charm_scenario.py
@@ -1,6 +1,12 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
+
+from unittest.mock import patch
+
+import pytest
 import scenario
+from lightkube.resources.autoscaling_v2 import HorizontalPodAutoscaler
+from ops import ActiveStatus
 
 from charm import IstioBeaconCharm
 
@@ -10,3 +16,79 @@ def test_relation_changed_status():
     ctx = scenario.Context(IstioBeaconCharm)
     out = ctx.run(ctx.on.start(), scenario.State())
     assert out.unit_status.name == "unknown"
+
+
+@pytest.mark.parametrize("planned_units", [1, 3, 5])
+@patch.object(IstioBeaconCharm, "_is_waypoint_deployment_ready")
+@patch.object(IstioBeaconCharm, "_put_charm_on_mesh")
+@patch.object(IstioBeaconCharm, "_get_waypoint_resource_manager")
+@patch.object(IstioBeaconCharm, "_setup_proxy_pebble_service")
+def test_sync_all_triggers_hpa_reconcile(
+    mock_setup_proxy_pebble_service,
+    mock_get_waypoint_resource_manager,
+    mock_put_charm_on_mesh,
+    mock_is_waypoint_deployment_ready,
+    istio_beacon_context,
+    planned_units,
+):
+    """Assert that HPA reconciliation is invoked in _sync_waypoint_resources.
+
+    Also check if the HPA spec contains the right number of replicas.
+    """
+    mock_waypoint_resource_manager = mock_get_waypoint_resource_manager.return_value
+    state = scenario.State(relations=[], leader=True, planned_units=planned_units)
+
+    result = istio_beacon_context.run(istio_beacon_context.on.config_changed(), state)
+
+    mock_get_waypoint_resource_manager.assert_called_once()
+    mock_waypoint_resource_manager.reconcile.assert_called_once()
+    resources = mock_waypoint_resource_manager.reconcile.call_args.args[0]
+
+    # we expect exactly two resources: the Waypoint and the HPA
+    assert len(resources) == 2
+
+    # filter out only the HPA object
+    hpas = [r for r in resources if isinstance(r, HorizontalPodAutoscaler)]
+    assert len(hpas) == 1
+
+    hpa = hpas[0]
+    assert hpa.spec.minReplicas == planned_units  # pyright: ignore[reportOptionalMemberAccess]
+    assert hpa.spec.maxReplicas == planned_units  # pyright: ignore[reportOptionalMemberAccess]
+
+    assert isinstance(result.unit_status, ActiveStatus)
+
+
+@pytest.mark.parametrize(
+    "planned_units, call_count",
+    [
+        (0, 1),  # last unit → we should clean up
+        (1, 0),  # still 1 (scale-down to 1) → skip
+        (2, 0),  # >1 (scale-down to >1) → skip
+    ],
+)
+@patch.object(IstioBeaconCharm, "_get_waypoint_resource_manager")
+@patch.object(IstioBeaconCharm, "_get_authorization_policy_resource_manager")
+def test_on_remove_deletes_hpa_only_when_last_unit(
+    mock_get_authorization_policy_resource_manager,
+    mock_get_waypoint_resource_manager,
+    istio_beacon_context,
+    planned_units,
+    call_count,
+):
+    """Assert that the KRM's (waypoint and authorization policy) delete method is called only when the last unit is about to be removed.
+
+    Also test the vice-versa is true, that the delete methods from KRM is not called when scaling down to non-zero units.
+    """
+    state = scenario.State(
+        relations=[],
+        leader=False,
+        planned_units=planned_units,
+    )
+
+    istio_beacon_context.run(istio_beacon_context.on.remove(), state)
+
+    mock_waypoint_resource_manager = mock_get_waypoint_resource_manager.return_value
+    assert mock_waypoint_resource_manager.delete.call_count == call_count
+
+    mock_authorization_policy_resource_manager = mock_get_authorization_policy_resource_manager.return_value
+    assert mock_authorization_policy_resource_manager.delete.call_count == call_count


### PR DESCRIPTION
## Issue
Beacon's replicas goes into a blocked state when the charm is scaled to more than 1 as described in issue #15. 


## Solution
Following the [solution](https://github.com/canonical/istio-ingress-k8s-operator/pull/61) for the `istio-ingress-k8s` charm: 

- Move the non-leader charm units into Active status with a message saying they are waiting to be a leader
- Add a [HorizontalPodAutoscaler](https://istio.io/latest/docs/tasks/traffic-management/ingress/gateway-api/#automated-deployment) to scale the waypoint pods automatically along with the charms
- Put all the charm operations behind a leader guard
- Add scenario and integration tests

## Context
The removal of the application resources specifically is not put behind a leader guard following this [conversation](https://github.com/canonical/istio-ingress-k8s-operator/pull/61#discussion_r2056539971)


## Testing Instructions
```bash
juju add-model istio-system
juju deploy istio-k8s --trust --channel=2/edge

# clone the source branch
charmcraft pack
juju deploy ./istio-beacon-k8s_ubuntu@22.04-amd64.charm --trust --resource metrics-proxy-image=docker.io/ibraaoad/metrics-proxy:v0.1.0
juju scale-application istio-beacon-k8s 3
juju status --watch 2s

juju scale-application istio-beacon-k8s 1
```