### PR TITLE
feat: added a tf module for istio-beacon charm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,9 @@ __pycache__/
 .idea
 .vscode/
 tests/integration/testers/service-mesh-tester/lib/*
+
+# Terraform files
+terraform/**/*.tfstate
+terraform/**/*.tfstate.*
+terraform/**/.terraform/
+terraform/**/.terraform.lock.hcl

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,66 @@
+<!-- BEGIN_TF_DOCS -->
+# Istio Beacon K8s Terraform Module
+
+This is a Terraform module facilitating the deployment of istio-beacon-k8s, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs).
+
+For detailed information on Istio and Canonical Service Mesh, see the [official documentation](https://canonical-service-mesh-documentation.readthedocs-hosted.com/en/latest/).
+
+## Usage
+
+Create `main.tf`:
+
+```hcl
+module "istio_beacon" {
+  source  = "git::https://github.com/canonical/istio-beacon-k8s-operator//terraform"
+  model   = juju_model.k8s.name
+  channel = "1/stable"
+}
+```
+
+```sh
+$ terraform apply
+```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
+| <a name="requirement_juju"></a> [juju](#requirement\_juju) | >= 0.14.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_juju"></a> [juju](#provider\_juju) | 0.20.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [juju_application.istio_beacon](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Name to give the deployed application | `string` | `"istio-beacon"` | no |
+| <a name="input_channel"></a> [channel](#input\_channel) | Channel that the charm is deployed from | `string` | n/a | yes |
+| <a name="input_config"></a> [config](#input\_config) | Map of the charm configuration options | `map(string)` | `{}` | no |
+| <a name="input_constraints"></a> [constraints](#input\_constraints) | String listing constraints for this application | `string` | `"arch=amd64"` | no |
+| <a name="input_model"></a> [model](#input\_model) | Reference to an existing model resource or data source for the model to deploy to | `string` | n/a | yes |
+| <a name="input_revision"></a> [revision](#input\_revision) | Revision number of the charm | `number` | `null` | no |
+| <a name="input_storage_directives"></a> [storage\_directives](#input\_storage\_directives) | Map of storage used by the application, which defaults to 1 GB, allocated by Juju | `map(string)` | `{}` | no |
+| <a name="input_units"></a> [units](#input\_units) | Unit count/scale | `number` | `1` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_app_name"></a> [app\_name](#output\_app\_name) | n/a |
+| <a name="output_endpoints"></a> [endpoints](#output\_endpoints) | n/a |
+<!-- END_TF_DOCS -->

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,39 @@
+/**
+ * # Istio Beacon K8s Terraform Module
+ *
+ * This is a Terraform module facilitating the deployment of istio-beacon-k8s, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs).
+ *
+ * For detailed information on Istio and Canonical Service Mesh, see the [official documentation](https://canonical-service-mesh-documentation.readthedocs-hosted.com/en/latest/).
+ *
+ * ## Usage
+ *
+ * Create `main.tf`:
+ *
+ * ```hcl
+ * module "istio_beacon" {
+ *   source  = "git::https://github.com/canonical/istio-beacon-k8s-operator//terraform"
+ *   model   = juju_model.k8s.name
+ *   channel = "1/stable"
+ * }
+ * ```
+ *
+ * ```sh
+ * $ terraform apply
+ * ```
+ */
+
+resource "juju_application" "istio_beacon" {
+  name               = var.app_name
+  config             = var.config
+  constraints        = var.constraints
+  model              = var.model
+  storage_directives = var.storage_directives
+  trust              = true
+  units              = var.units
+
+  charm {
+    name     = "istio-beacon-k8s"
+    channel  = var.channel
+    revision = var.revision
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,14 @@
+output "app_name" {
+  value = juju_application.istio_beacon.name
+}
+
+output "endpoints" {
+  value = {
+    # Requires
+    charm_tracing = "charm-tracing"
+
+    # Provides
+    service_mesh     = "service-mesh"
+    metrics_endpoint = "metrics-endpoint"
+  }
+}

--- a/terraform/tests/examples/istio-beacon.tf
+++ b/terraform/tests/examples/istio-beacon.tf
@@ -1,0 +1,89 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 0.14.0"
+    }
+  }
+}
+
+provider "juju" {
+  # These values can be set through environment variables:
+  # JUJU_CONTROLLER_ADDRESSES - controller endpoint
+  # JUJU_USERNAME - username
+  # JUJU_PASSWORD - password
+  # JUJU_CA_CERT - CA certificate
+
+  # Or you can specify them explicitly:
+  # controller_addresses = "10.0.0.1:17070"
+  # username = "admin"
+  # password = "your-password"
+  # ca_certificate = file("~/juju-ca-cert.crt")
+}
+
+# Create a model for testing
+resource "juju_model" "istio_beacon_test" {
+  name = "istio-beacon-test"
+
+  # Specify your cloud/substrate
+  # For example, for microk8s:
+  # cloud {
+  #   name = "microk8s"
+  # }
+
+  # For other Kubernetes clouds, adjust accordingly
+}
+
+# Deploy Istio using the istio-k8s-operator module
+module "istio" {
+  source   = "git::https://github.com/canonical/istio-k8s-operator//terraform"
+  model    = juju_model.istio_beacon_test.name
+  channel  = "2/edge"
+  app_name = "istio"
+  units    = 1
+}
+
+# Deploy Istio Beacon using the module (depends on Istio being deployed first)
+module "istio_beacon" {
+  source = "../.."
+
+  # Required: reference to the model
+  model = juju_model.istio_beacon_test.name
+
+  # Required: specify the channel
+  channel = "2/edge"
+
+  # Optional: customize the deployment
+  app_name = "istio-beacon"
+  units    = 1
+
+  # Optional: charm configuration
+  config = {
+    # Automatically create Istio authorization policies (default: true)
+    manage-authorization-policies = true
+
+    # Add entire model to the service mesh (default: false)
+    model-on-mesh = false
+
+    # Timeout for waypoint deployment readiness in seconds (default: 100)
+    ready-timeout = 100
+  }
+
+  # Optional: constraints
+  constraints = "arch=amd64"
+
+  # Ensure Istio is deployed before the beacon
+  depends_on = [module.istio]
+}
+
+# Outputs to verify deployment
+output "istio_beacon_app_name" {
+  value       = module.istio_beacon.app_name
+  description = "The name of the deployed Istio Beacon application"
+}
+
+output "istio_beacon_endpoints" {
+  value       = module.istio_beacon.endpoints
+  description = "Available endpoints for the Istio Beacon charm"
+}

--- a/terraform/tests/integration/main.tftest.hcl
+++ b/terraform/tests/integration/main.tftest.hcl
@@ -1,0 +1,177 @@
+# Integration tests for Istio Beacon K8s Terraform module
+#
+# Prerequisites:
+# - Istio must be deployed in the test model before running these tests
+# - You can deploy Istio using: terraform apply -var="model=istio-beacon-test" \
+#   -var="channel=2/edge" git::https://github.com/canonical/istio-k8s-operator//terraform
+
+variables {
+  test_model = "istio-beacon-test"
+}
+
+provider "juju" {
+  # Provider configuration will use environment variables in CI
+}
+
+# Test basic deployment of Istio Beacon
+# Note: This test assumes Istio is already deployed in the target model
+run "basic_deployment" {
+  command = apply
+
+  variables {
+    model   = var.test_model
+    channel = "2/edge"
+  }
+
+  assert {
+    condition     = juju_application.istio_beacon.name == "istio-beacon"
+    error_message = "Default application name should be 'istio-beacon'"
+  }
+
+  assert {
+    condition     = juju_application.istio_beacon.units == 1
+    error_message = "Default units should be 1"
+  }
+
+  assert {
+    condition     = juju_application.istio_beacon.trust == true
+    error_message = "Trust should be enabled for Kubernetes permissions"
+  }
+
+  assert {
+    condition     = juju_application.istio_beacon.charm[0].name == "istio-beacon-k8s"
+    error_message = "Charm name should be 'istio-beacon-k8s'"
+  }
+
+  assert {
+    condition     = juju_application.istio_beacon.charm[0].channel == "2/edge"
+    error_message = "Channel should be '2/edge'"
+  }
+}
+
+# Test configured deployment with custom settings
+run "configured_deployment" {
+  command = apply
+
+  variables {
+    model    = var.test_model
+    channel  = "2/edge"
+    app_name = "custom-beacon"
+    units    = 2
+    config = {
+      manage-authorization-policies = false
+      model-on-mesh                 = true
+      ready-timeout                 = 150
+    }
+  }
+
+  assert {
+    condition     = juju_application.istio_beacon.name == "custom-beacon"
+    error_message = "Application name should be 'custom-beacon'"
+  }
+
+  assert {
+    condition     = juju_application.istio_beacon.units == 2
+    error_message = "Units should be 2"
+  }
+
+  assert {
+    condition     = juju_application.istio_beacon.config["manage-authorization-policies"] == "false"
+    error_message = "manage-authorization-policies should be disabled"
+  }
+
+  assert {
+    condition     = juju_application.istio_beacon.config["model-on-mesh"] == "true"
+    error_message = "model-on-mesh should be enabled"
+  }
+
+  assert {
+    condition     = juju_application.istio_beacon.config["ready-timeout"] == "150"
+    error_message = "ready-timeout should be 150"
+  }
+}
+
+# Test scaling capabilities
+run "scale_deployment" {
+  command = apply
+
+  variables {
+    model   = var.test_model
+    channel = "2/edge"
+    units   = 3
+  }
+
+  assert {
+    condition     = juju_application.istio_beacon.units == 3
+    error_message = "Should scale to 3 units"
+  }
+}
+
+# Test specific revision deployment
+run "revision_deployment" {
+  command = apply
+
+  variables {
+    model    = var.test_model
+    channel  = "2/edge"
+    revision = 36
+  }
+
+  assert {
+    condition     = juju_application.istio_beacon.charm[0].revision == 36
+    error_message = "Should deploy specific revision 36"
+  }
+}
+
+# Verify outputs
+run "verify_outputs" {
+  command = apply
+
+  variables {
+    model    = var.test_model
+    channel  = "2/edge"
+    app_name = "test-beacon"
+  }
+
+  assert {
+    condition     = output.app_name == "test-beacon"
+    error_message = "Output app_name should match input"
+  }
+
+  assert {
+    condition     = length(output.endpoints) == 3
+    error_message = "Should have 3 endpoints"
+  }
+
+  assert {
+    condition     = output.endpoints.charm_tracing == "charm-tracing"
+    error_message = "Should have charm-tracing endpoint"
+  }
+
+  assert {
+    condition     = output.endpoints.service_mesh == "service-mesh"
+    error_message = "Should have service-mesh endpoint"
+  }
+
+  assert {
+    condition     = output.endpoints.metrics_endpoint == "metrics-endpoint"
+    error_message = "Should have metrics-endpoint endpoint"
+  }
+}
+
+# Test deployment with empty config (should succeed)
+run "empty_config_deployment" {
+  command = apply
+
+  variables {
+    model   = var.test_model
+    channel = "2/edge"
+    config  = {}
+  }
+
+  assert {
+    condition     = juju_application.istio_beacon.name == "istio-beacon"
+    error_message = "Should deploy successfully with empty config"
+  }
+}
+

--- a/terraform/tests/plan/main.tftest.hcl
+++ b/terraform/tests/plan/main.tftest.hcl
@@ -1,0 +1,234 @@
+# Test configuration for Istio Beacon K8s Terraform module
+
+variables {
+  test_model_name = "istio-beacon-test-model"
+}
+
+provider "juju" {
+  # Provider configuration will use environment variables in CI
+}
+
+# Test default deployment
+run "default_deployment" {
+  command = plan
+
+  variables {
+    model   = var.test_model_name
+    channel = "2/edge"
+  }
+
+  assert {
+    condition     = juju_application.istio_beacon.name == "istio-beacon"
+    error_message = "Default application name should be 'istio-beacon'"
+  }
+
+  assert {
+    condition     = juju_application.istio_beacon.units == 1
+    error_message = "Default units should be 1"
+  }
+
+  assert {
+    condition     = juju_application.istio_beacon.trust == true
+    error_message = "Trust should be enabled for Kubernetes permissions"
+  }
+
+  assert {
+    condition     = juju_application.istio_beacon.constraints == "arch=amd64"
+    error_message = "Default constraints should be 'arch=amd64'"
+  }
+}
+
+# Test custom application name
+run "custom_app_name" {
+  command = plan
+
+  variables {
+    model    = var.test_model_name
+    app_name = "my-beacon"
+    channel  = "2/edge"
+  }
+
+  assert {
+    condition     = juju_application.istio_beacon.name == "my-beacon"
+    error_message = "Application name should be 'my-beacon'"
+  }
+}
+
+# Test scaling configuration
+run "scaled_deployment" {
+  command = plan
+
+  variables {
+    model   = var.test_model_name
+    channel = "2/edge"
+    units   = 3
+  }
+
+  assert {
+    condition     = juju_application.istio_beacon.units == 3
+    error_message = "Units should be 3"
+  }
+}
+
+# Test channel configuration
+run "channel_configuration" {
+  command = plan
+
+  variables {
+    model   = var.test_model_name
+    channel = "2/stable"
+  }
+
+  assert {
+    condition     = juju_application.istio_beacon.charm[0].channel == "2/stable"
+    error_message = "Channel should be '2/stable'"
+  }
+}
+
+# Test revision configuration
+run "revision_configuration" {
+  command = plan
+
+  variables {
+    model    = var.test_model_name
+    channel  = "2/edge"
+    revision = 36
+  }
+
+  assert {
+    condition     = juju_application.istio_beacon.charm[0].revision == 36
+    error_message = "Revision should be 36"
+  }
+}
+
+# Test charm configuration
+run "charm_config" {
+  command = plan
+
+  variables {
+    model   = var.test_model_name
+    channel = "2/edge"
+    config = {
+      manage-authorization-policies = false
+      model-on-mesh                 = true
+      ready-timeout                 = 200
+    }
+  }
+
+  assert {
+    condition     = juju_application.istio_beacon.config["manage-authorization-policies"] == "false"
+    error_message = "manage-authorization-policies should be disabled in config"
+  }
+
+  assert {
+    condition     = juju_application.istio_beacon.config["model-on-mesh"] == "true"
+    error_message = "model-on-mesh should be enabled"
+  }
+
+  assert {
+    condition     = juju_application.istio_beacon.config["ready-timeout"] == "200"
+    error_message = "ready-timeout should be 200"
+  }
+}
+
+# Test custom constraints
+run "custom_constraints" {
+  command = plan
+
+  variables {
+    model       = var.test_model_name
+    channel     = "2/edge"
+    constraints = "arch=arm64 cores=4 mem=8G"
+  }
+
+  assert {
+    condition     = juju_application.istio_beacon.constraints == "arch=arm64 cores=4 mem=8G"
+    error_message = "Constraints should match the custom value"
+  }
+}
+
+# Test storage directives
+run "storage_directives" {
+  command = plan
+
+  variables {
+    model   = var.test_model_name
+    channel = "2/edge"
+    storage_directives = {
+      data = "ebs,10G"
+    }
+  }
+
+  assert {
+    condition     = juju_application.istio_beacon.storage_directives["data"] == "ebs,10G"
+    error_message = "Storage directive for 'data' should be 'ebs,10G'"
+  }
+}
+
+# Test outputs
+run "output_values" {
+  command = plan
+
+  variables {
+    model    = var.test_model_name
+    app_name = "test-beacon"
+    channel  = "2/edge"
+  }
+
+  assert {
+    condition     = output.app_name == "test-beacon"
+    error_message = "Output app_name should match the input"
+  }
+
+  assert {
+    condition     = length(output.endpoints) == 3
+    error_message = "Should have 3 endpoints (1 requires, 2 provides)"
+  }
+
+  assert {
+    condition     = output.endpoints.charm_tracing == "charm-tracing"
+    error_message = "Should have charm-tracing endpoint"
+  }
+
+  assert {
+    condition     = output.endpoints.service_mesh == "service-mesh"
+    error_message = "Should have service-mesh endpoint"
+  }
+
+  assert {
+    condition     = output.endpoints.metrics_endpoint == "metrics-endpoint"
+    error_message = "Should have metrics-endpoint endpoint"
+  }
+}
+
+# Test empty config
+run "empty_config" {
+  command = plan
+
+  variables {
+    model   = var.test_model_name
+    channel = "2/edge"
+    config  = {}
+  }
+
+  # Should succeed without errors - config is optional
+  assert {
+    condition     = juju_application.istio_beacon.name == "istio-beacon"
+    error_message = "Should deploy successfully with empty config"
+  }
+}
+
+# Test model reference
+run "model_reference" {
+  command = plan
+
+  variables {
+    model   = "different-model"
+    channel = "2/edge"
+  }
+
+  assert {
+    condition     = juju_application.istio_beacon.model == "different-model"
+    error_message = "Model should be 'different-model'"
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,45 @@
+variable "app_name" {
+  description = "Name to give the deployed application"
+  type        = string
+  default     = "istio-beacon"
+}
+
+variable "channel" {
+  description = "Channel that the charm is deployed from"
+  type        = string
+}
+
+variable "config" {
+  description = "Map of the charm configuration options"
+  type        = map(string)
+  default     = {}
+}
+
+variable "constraints" {
+  description = "String listing constraints for this application"
+  type        = string
+  default     = "arch=amd64"
+}
+
+variable "model" {
+  description = "Reference to an existing model resource or data source for the model to deploy to"
+  type        = string
+}
+
+variable "revision" {
+  description = "Revision number of the charm"
+  type        = number
+  default     = null
+}
+
+variable "storage_directives" {
+  description = "Map of storage used by the application, which defaults to 1 GB, allocated by Juju"
+  type        = map(string)
+  default     = {}
+}
+
+variable "units" {
+  description = "Unit count/scale"
+  type        = number
+  default     = 1
+}

--- a/terraform/version.tf
+++ b/terraform/version.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 0.14.0"
+    }
+  }
+}


### PR DESCRIPTION
## Feature
Adds a terraform module for the istio-beacon-k8s charm so the charm can be deployed using tf and the juju tf operator.

The README.md for the terraform module is autogenerated using the header from `main.tf` by the [terraform-docs](https://github.com/terraform-docs/terraform-docs)

Also added the following tests for the module
- manual: tf script to manually adapt and investigate the terraform deployment
- plan: automated plan (kind of unit) tests to verify the planned terraform deployment
- integration: automated tf deployment and post deployment verification tests

## Testing Instructions
1. install terraform
```bash
sudo snap install terraform --classic
```

2. clone the repo and cd to the terraform directory
```bash
cd terraform
```

4. To manually test the tf deployment of the `istio-k8s` tf module, the `istio-beacon.tf` example terraform script can be used. 
```bash
cd tests/examples

# edit the istio-beacon.tf to adjust the deployment accordingly
# terraform init, plan and apply
terraform init
terraform plan
terraform apply
```

5. To run the plan tests which will plan (`terraform plan`) the deployment of the istio-beacon-k8s tf module with different possible configurations and verify if the output of the plan is as expected -
```bash
# run from the terraform directory
terraform init
terraform test -test-directory=tests/plan 
```

6. To run the integration tests which will apply (`terraform apply`) the deployment of the istio-beacon-k8s tf module with different possible configurations and verify if the deployment was done with the expected configuration -
```bash
# run from the terraform directory
# terraform integration tests require an pre-existing juju model called istio-test
juju add-model istio-beacon-test
juju deploy istio-k8s --trust --channel=2/edge
terraform init
terraform test -test-directory=tests/integration 
```
terraform will make sure to clean deployed resources if the integration test is successful

## Docs

The README.md for the tf module was autogenerated using the [terraform-docs](https://github.com/terraform-docs/terraform-docs) tool.

```bash
sudo snap install terraform-docs
cd terraform
terraform-docs markdown table --output-file README.md . 
```
