### PR TITLE
feat: add an option to auto allow comm between units of the charm

### DIFF
--- a/tests/integration/test_charm_scaling.py
+++ b/tests/integration/test_charm_scaling.py
@@ -80,28 +80,6 @@ async def test_service_mesh_relation(ops_test: OpsTest, service_mesh_tester):
 @pytest.mark.parametrize(
     "n_units",
     (
-        # Scale up from 1 to 2
-        2,
-        # Scale down to 1
-        1,
-    ),
-)
-async def test_service_mesh_consumer_scaling(ops_test: OpsTest, n_units):
-    """Tests if the ServiceMeshConsumer class allows the consumer app to scale without errors."""
-    assert ops_test.model
-    await ops_test.model.applications[TESTER_APP_NAME].scale(n_units)
-    await ops_test.model.wait_for_idle(
-        [TESTER_APP_NAME],
-        status="active",
-        timeout=200,
-        raise_on_error=False,
-    )
-
-
-@pytest.mark.abort_on_fail
-@pytest.mark.parametrize(
-    "n_units",
-    (
         # Scale up from 1 to 3
         3,
         # Scale down to 2

--- a/tests/integration/testers/service-mesh-tester/charmcraft.yaml
+++ b/tests/integration/testers/service-mesh-tester/charmcraft.yaml
@@ -14,6 +14,11 @@ bases:
 
 config:
   options:
+    auto-allow-intra-app-access:
+      type: boolean
+      default: false
+      description: |
+        Used for `ServiceMeshConsumer`'s `auto_allow_intra_app_access` argument, which controls whether the units of this charm are allowed to communicate with each other or not.
     auto-join-mesh:
       type: boolean
       default: true

--- a/tests/integration/testers/service-mesh-tester/src/charm.py
+++ b/tests/integration/testers/service-mesh-tester/src/charm.py
@@ -42,6 +42,7 @@ class ServiceMeshTester(CharmBase):
                 ),
             ],
             auto_join=bool(self.config["auto-join-mesh"]),
+            auto_allow_intra_app_access=bool(self.config["auto-allow-intra-app-access"]),
         )
 
         self.framework.observe(self.on.echo_server_pebble_ready, self.on_pebble_ready)


### PR DESCRIPTION
## Issue
fixes issue #106 


## Solution

- The ServiceMeshConsumer now includes a bollean argument `auto_allow_intra_app_access`
- When set to True, the `build_mesh_policies` method automatically appends an `UnitPolicy` with from the target apps service account selecting all the pods with the target app  label


## Testing Instructions
Can be tested using scaled Service Mesh Tester with more than 1 unit by setting the `auto_allow_intra_app_access` in the ServiceMeshConsumer to true and curling another units pod url from a unit. 
