### PR TITLE
feat: add mesh type to service mesh interface

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -117,7 +117,11 @@ class IstioBeaconCharm(ops.CharmBase):
         self.framework.observe(
             self.on.metrics_proxy_pebble_ready, self._metrics_proxy_pebble_ready
         )
-        self._mesh = ServiceMeshProvider(self, labels=self.mesh_labels_for_service_mesh_relation())
+        self._mesh = ServiceMeshProvider(
+            self,
+            labels=self.mesh_labels_for_service_mesh_relation(),
+            mesh_type=MeshType.istio,
+        )
 
         self.framework.observe(self.on["service-mesh"].relation_changed, self.on_mesh_changed)
         self.framework.observe(self.on["service-mesh"].relation_broken, self.on_mesh_broken)

--- a/tests/unit/test_mesh_consumer.py
+++ b/tests/unit/test_mesh_consumer.py
@@ -443,10 +443,10 @@ def test_getting_relation_data(patched_reconcile: MagicMock):
         mesh_type=mesh_type_actual,
     )
     mesh_relation = scenario.Relation(
-        endpoint="service-mesh", 
-        interface="service_mesh", 
+        endpoint="service-mesh",
+        interface="service_mesh",
         remote_app_data={
-            "labels": json.dumps(labels_actual), 
+            "labels": json.dumps(labels_actual),
             "mesh_type": json.dumps(mesh_type_actual)
         }
     )

--- a/tests/unit/test_mesh_consumer.py
+++ b/tests/unit/test_mesh_consumer.py
@@ -442,7 +442,14 @@ def test_getting_relation_data(patched_reconcile: MagicMock):
         labels=labels_actual,
         mesh_type=mesh_type_actual,
     )
-    mesh_relation = scenario.Relation(endpoint="service-mesh", interface="service_mesh", remote_app_data={"labels": json.dumps(labels_actual), "mesh_type": json.dumps(mesh_type_actual)})
+    mesh_relation = scenario.Relation(
+        endpoint="service-mesh", 
+        interface="service_mesh", 
+        remote_app_data={
+            "labels": json.dumps(labels_actual), 
+            "mesh_type": json.dumps(mesh_type_actual)
+        }
+    )
     state = scenario.State(
         relations={
             mesh_relation,

--- a/tests/unit/test_mesh_consumer.py
+++ b/tests/unit/test_mesh_consumer.py
@@ -10,6 +10,7 @@ import scenario
 from charms.istio_beacon_k8s.v0.service_mesh import (
     AppPolicy,
     Endpoint,
+    MeshType,
     Policy,
     ServiceMeshConsumer,
     ServiceMeshProviderAppData,
@@ -436,10 +437,12 @@ def test_getting_relation_data(patched_reconcile: MagicMock):
     """Test that the consumer can read relation data set by a provider."""
     ctx = consumer_context([AppPolicy(relation="rela", endpoints=[ENDPOINT_A], service=None)])
     labels_actual = {"label1": "value1", "label2": "value2"}
+    mesh_type_actual = MeshType.istio
     expected_data = ServiceMeshProviderAppData(
-        labels=labels_actual
+        labels=labels_actual,
+        mesh_type=mesh_type_actual,
     )
-    mesh_relation = scenario.Relation(endpoint="service-mesh", interface="service_mesh", remote_app_data={"labels": json.dumps(labels_actual)})
+    mesh_relation = scenario.Relation(endpoint="service-mesh", interface="service_mesh", remote_app_data={"labels": json.dumps(labels_actual), "mesh_type": json.dumps(mesh_type_actual)})
     state = scenario.State(
         relations={
             mesh_relation,
@@ -451,4 +454,5 @@ def test_getting_relation_data(patched_reconcile: MagicMock):
         state,
     ) as manager:
         assert labels_actual == manager.charm.mesh.labels()
+        assert mesh_type_actual == manager.charm.mesh.mesh_type()
         assert expected_data == manager.charm.mesh._get_app_data()

--- a/tests/unit/test_mesh_provider.py
+++ b/tests/unit/test_mesh_provider.py
@@ -1,7 +1,11 @@
 import json
 
 import scenario
-from charms.istio_beacon_k8s.v0.service_mesh import ServiceMeshProvider, ServiceMeshProviderAppData
+from charms.istio_beacon_k8s.v0.service_mesh import (
+    MeshType,
+    ServiceMeshProvider,
+    ServiceMeshProviderAppData,
+)
 from ops import CharmBase
 
 MESH_LABELS = {
@@ -10,6 +14,7 @@ MESH_LABELS = {
 }
 MESH_RELATION_NAME = "service-mesh-relation"
 MESH_INTERFACE_NAME = "service_mesh_interface"
+MESH_TYPE = MeshType.istio
 
 
 def provider_context() -> scenario.Context:
@@ -24,7 +29,12 @@ def provider_context() -> scenario.Context:
     class Charm(CharmBase):
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
-            self.mesh = ServiceMeshProvider(self, labels=MESH_LABELS, mesh_relation_name=MESH_RELATION_NAME)
+            self.mesh = ServiceMeshProvider(
+                self,
+                labels=MESH_LABELS,
+                mesh_relation_name=MESH_RELATION_NAME,
+                mesh_type=MESH_TYPE
+            )
 
     return scenario.Context(Charm, meta)
 
@@ -43,3 +53,4 @@ def test_provider_sends_data():
     raw_data = {k: json.loads(v) for k, v in out.get_relation(mesh_relation.id).local_app_data.items()}
     actual = ServiceMeshProviderAppData.model_validate(raw_data)
     assert actual.labels == MESH_LABELS
+    assert actual.mesh_type == MESH_TYPE

--- a/tests/unit/test_mesh_provider.py
+++ b/tests/unit/test_mesh_provider.py
@@ -1,0 +1,45 @@
+import json
+
+import scenario
+from charms.istio_beacon_k8s.v0.service_mesh import ServiceMeshProvider, ServiceMeshProviderAppData
+from ops import CharmBase
+
+MESH_LABELS = {
+    "label1": "value1",
+    "label2": "value2",
+}
+MESH_RELATION_NAME = "service-mesh-relation"
+MESH_INTERFACE_NAME = "service_mesh_interface"
+
+
+def provider_context() -> scenario.Context:
+    meta = {
+        "name": "provider-charm",
+        "provides": {
+            MESH_RELATION_NAME: {"interface": MESH_INTERFACE_NAME},
+        },
+    }
+
+
+    class Charm(CharmBase):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.mesh = ServiceMeshProvider(self, labels=MESH_LABELS, mesh_relation_name=MESH_RELATION_NAME)
+
+    return scenario.Context(Charm, meta)
+
+
+def test_provider_sends_data():
+    ctx = provider_context()
+    mesh_relation = scenario.Relation(
+        endpoint=MESH_RELATION_NAME,
+        interface=MESH_INTERFACE_NAME,
+    )
+    state = scenario.State(
+        relations=[mesh_relation],
+        leader=True,
+    )
+    out = ctx.run(ctx.on.relation_created(mesh_relation), state)
+    raw_data = {k: json.loads(v) for k, v in out.get_relation(mesh_relation.id).local_app_data.items()}
+    actual = ServiceMeshProviderAppData.model_validate(raw_data)
+    assert actual.labels == MESH_LABELS


### PR DESCRIPTION
## Issue
Fixes #114 

## Solution
Adds a `mesh_type` parameter to the service mesh relation.  Adds handlers for the service mesh provider and consumer objects

## Context
.

## Testing Instructions
Asserted working in unit tests

## Upgrade Notes
