### PR TITLE
ci: switch central ci jobs to v1

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -9,8 +9,7 @@ on:
 jobs:
   pull-request:
     name: PR
-    # TODO: Fixes https://github.com/juju/juju/issues/20738. Replace with standard version tag after the linkes issue is fixed.
-    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@chore/pin-juju-3.6.9
+    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@v1
     secrets: inherit
     with:
       automatically-retry-hooks: true # A fix for #8

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,8 +9,7 @@ on:
 
 jobs:
   release:
-    # TODO: Fixes https://github.com/juju/juju/issues/20738. Replace with standard version tag after the linkes issue is fixed.
-    uses: canonical/observability/.github/workflows/charm-release.yaml@chore/pin-juju-3.6.9
+    uses: canonical/observability/.github/workflows/charm-release.yaml@v1
     secrets: inherit
     with:
       default-track: 2


### PR DESCRIPTION
switch central ci version back to v1 since Juju 3.6.10 is now dropped
