### PR TITLE
fix: allow PRM to be inited without mesh_type

### DIFF
--- a/lib/charms/istio_beacon_k8s/v0/service_mesh.py
+++ b/lib/charms/istio_beacon_k8s/v0/service_mesh.py
@@ -167,11 +167,14 @@ from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.apps_v1 import StatefulSet
 from lightkube.resources.core_v1 import ConfigMap, Service
 from lightkube_extensions.batch import KubernetesResourceManager
-from lightkube_extensions.types import LightkubeResourcesList
+from lightkube_extensions.types import (
+    LightkubeResourcesList,
+    LightkubeResourceTypesSet,
+)
 from ops import CharmBase, Object, RelationMapping
 from pydantic import Field
 
-RESOURCE_TYPES = {
+RESOURCE_TYPES = {  # type: ignore
     "AuthorizationPolicy": create_namespaced_resource(
         "security.istio.io",
         "v1",
@@ -179,13 +182,13 @@ RESOURCE_TYPES = {
         "authorizationpolicies",
     ),
 }
-POLICY_RESOURCE_TYPES = {
+POLICY_RESOURCE_TYPES = {  # type: ignore
     "istio": {RESOURCE_TYPES["AuthorizationPolicy"]},
 }
 
 LIBID = "3f40cb7e3569454a92ac2541c5ca0a0c"  # Never change this
 LIBAPI = 0
-LIBPATCH = 12
+LIBPATCH = 13
 
 PYDEPS = [
     "lightkube",
@@ -1014,7 +1017,6 @@ class PolicyResourceManager():
             policies = self._get_policies_i_manager()
             prm.reconcile(polcies)
     ````
-
     Args:
         charm (ops.CharmBase): The charm instantiating this object.
         lightkube_client (lightkube.Client): Lightkube Client to use for all k8s operations.
@@ -1046,14 +1048,22 @@ class PolicyResourceManager():
         self,
         charm: CharmBase,
         lightkube_client: Client,
-        mesh_type: MeshType,
+        mesh_type: Optional[MeshType] = None,
         labels: Optional[Dict] = None,
         logger: Optional[logging.Logger] = None,
     ):
         self._app_name = charm.app.name
         self._model_name = charm.model.name
         self._mesh_type = mesh_type
-        resource_types = POLICY_RESOURCE_TYPES[self._mesh_type]
+
+        # It should be possible to init the PRM without any mesh type.
+        # PRM should allow non-service mesh charms to identify and delete policies without any
+        # mesh_type. This can happen in the case of a departed service-mesh relation in on service mesh charms.
+        if self._mesh_type:
+            resource_types = POLICY_RESOURCE_TYPES[self._mesh_type]
+        else:
+            resource_types = self._get_all_supported_policy_resource_types()
+
         if logger is None:
             self.log = logging.getLogger(__name__)
         else:
@@ -1065,10 +1075,19 @@ class PolicyResourceManager():
             logger=self.log,
         )
 
+    @staticmethod
+    def _get_all_supported_policy_resource_types() -> LightkubeResourceTypesSet:  # type: ignore
+        """Return all the resource types supported by the PRM class."""
+        # Flatten all resource types from all mesh types into one set
+        resource_types: LightkubeResourceTypesSet = set()  # type: ignore
+        for mesh_resource_types in POLICY_RESOURCE_TYPES.values():
+            resource_types.update(mesh_resource_types)
+        return resource_types
+
     def _get_policy_resource_builder(self):
         if self._mesh_type == MeshType.istio:
             return _build_policy_resources_istio
-        raise ValueError(f"PolicyResourceManager instantiated wirh an unknown mesh type: {self._mesh_type.value}. Check Canonical Service Mesh documentation for currently supported mesh types.")
+        raise ValueError(f"PolicyResourceManager instantiated with an unknown mesh type: {self._mesh_type.value}. Check Canonical Service Mesh documentation for currently supported mesh types.")  # type: ignore
 
     def reconcile(self,
         policies: List[MeshPolicy],
@@ -1095,6 +1114,8 @@ class PolicyResourceManager():
                    marked as managed by another field manager.
             ignore_missing: *(optional)* Avoid raising 404 errors on deletion (defaults to True)
         """
+        if not self._mesh_type:
+            raise ValueError(f"PolicyResourceManager cannot reconcile policies for a {self._mesh_type} mesh_type.")
         mesh_typed_policy_resources_builder = self._get_policy_resource_builder()
         mesh_typed_policy_resources = mesh_typed_policy_resources_builder(self._app_name, self._model_name, policies)  # type: ignore
         self._krm.reconcile(mesh_typed_policy_resources, force=force, ignore_missing=ignore_missing)  # type: ignore
@@ -1107,4 +1128,12 @@ class PolicyResourceManager():
         Args:
             ignore_missing: *(optional)* Avoid raising 404 errors on deletion (defaults to True)
         """
-        self._krm.delete(ignore_missing=ignore_missing)
+        try:
+            self._krm.delete(ignore_missing=ignore_missing)
+        # FIXME: this is a workaround and should be handled by the upstream krm. Issue exists: https://github.com/canonical/lightkube-extensions/issues/4
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404 and ignore_missing:
+                # CRD doesn't exist, nothing to delete (only when ignore_missing=True)
+                self.log.info("CRD not found, skipping deletion")
+                return
+            raise


### PR DESCRIPTION
## Issue
The PolicyResourceManager currently needs a mesh_type to be sucessfully initialized. but in cases when non service mesh charms use it, there are use case when they might need to initialize the PRM without any mehs_type (for eg. when the service-mesh relation has departed and they need the PRM to delete the policies without knowing the mesh_type from the service-mesh relation).

This PR fixes this.

Additionally, a small workaround in added to catch a exception when the PRMs deleted method is called when there is no required CRD. This is only a quick workaround in the PRM and the actual fix must land in the upstream KubertenesResourceManager. An [issue](https://github.com/canonical/lightkube-extensions/issues/4) to fix this in the KRM exists.

NOTE: UPDATE LIB_PATCH IF MERGING AFTER #123
