### PR TITLE
refactor: PRM reconciles the mesh_type

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -217,7 +217,6 @@ class IstioBeaconCharm(ops.CharmBase):
         return PolicyResourceManager(
             self,
             lightkube_client=self.lightkube_client,
-            mesh_type=MeshType.istio,  # pyright: ignore
             labels=create_charm_default_labels(
                 self.app.name, self.model.name, scope=AUTHORIZATION_POLICY_LABEL
             ),
@@ -396,7 +395,7 @@ class IstioBeaconCharm(ops.CharmBase):
 
         # Manage charm (related to beacon) traffic authorization policies
         prm = self._get_authorization_policy_resource_manager()
-        prm.reconcile(mesh_policies)  # type: ignore
+        prm.reconcile(mesh_policies, MeshType.istio)  # type: ignore
         # Manage istio beacon's (modeoperator) authorization policies
         krm = self._get_modeloperator_policy_resource_manager()
         krm.reconcile(modeloperator_policies)  # type: ignore

--- a/tests/unit/test_policy_resource_manager.py
+++ b/tests/unit/test_policy_resource_manager.py
@@ -6,11 +6,8 @@ from unittest.mock import MagicMock, Mock, patch
 import httpx
 import pytest
 from charms.istio_beacon_k8s.v0.service_mesh import (
-    Endpoint,
-    MeshPolicy,
     MeshType,
     PolicyResourceManager,
-    PolicyTargetType,
 )
 from ops import CharmBase
 
@@ -28,44 +25,18 @@ def mock_lightkube_client():
     return MagicMock()
 
 
-def test_policy_resource_manager_reconcile_without_mesh_type_raises_error(mock_charm, mock_lightkube_client):
-    """Test reconcile raises ValueError when mesh_type is None."""
-    prm = PolicyResourceManager(
-        charm=mock_charm,
-        lightkube_client=mock_lightkube_client,
-        mesh_type=None,
-    )
-
-    policies = [
-        MeshPolicy(
-            source_namespace="source-ns",
-            source_app_name="source-app",
-            target_namespace="target-ns",
-            target_app_name="target-app",
-            target_type=PolicyTargetType.app,
-            endpoints=[Endpoint(ports=[80])]
-        )
-    ]
-
-    with pytest.raises(ValueError, match="PolicyResourceManager instantiated with an unknown mesh type"):
-        prm.reconcile(policies)
-
-
 def test_policy_resource_manager_reconcile_empty_policies_calls_delete(mock_charm, mock_lightkube_client):
     """Test reconcile calls delete when policies list is empty."""
     with patch('charms.istio_beacon_k8s.v0.service_mesh.KubernetesResourceManager'):
         prm = PolicyResourceManager(
             charm=mock_charm,
             lightkube_client=mock_lightkube_client,
-            mesh_type=None,  # Even with None mesh_type, empty policies should call delete
         )
 
         # Mock the _krm
         prm._krm = MagicMock()
-
         # Call reconcile with empty policies
-        prm.reconcile([])
-
+        prm.reconcile([], MeshType.istio)
         # Should call delete instead of trying to build policies
         prm._krm.delete.assert_called_once()
 
@@ -76,7 +47,6 @@ def test_policy_resource_manager_delete_handles_404_error(mock_charm, mock_light
         prm = PolicyResourceManager(
             charm=mock_charm,
             lightkube_client=mock_lightkube_client,
-            mesh_type=MeshType.istio,
         )
 
         # Mock the _krm and logger


### PR DESCRIPTION
We were initializing the `PolicyResourceManager` with the `mesh_type` but we were using this only when reconciling the policies which mean we had to make the `mesh_type` an optional arg and check for its validity. The current refactor moves this `mesh_type` arg from the `init` into the `reconcile` method forcing the users to call the reconcile with a valid `mesh_type`