### PR TITLE
fix(lib): makes the label patcher least intrusive

### DIFF
--- a/lib/charms/istio_beacon_k8s/v0/service_mesh.py
+++ b/lib/charms/istio_beacon_k8s/v0/service_mesh.py
@@ -180,7 +180,7 @@ POLICY_RESOURCE_TYPES = {
 
 LIBID = "3f40cb7e3569454a92ac2541c5ca0a0c"  # Never change this
 LIBAPI = 0
-LIBPATCH = 18
+LIBPATCH = 19
 
 PYDEPS = [
     "lightkube",
@@ -653,10 +653,7 @@ def reconcile_charm_labels(client: Client, app_name: str, namespace: str,  label
         labels: A dictionary of labels to set on the Charm's Kubernetes objects. Any labels that were previously created
                 by this method but omitted in `labels` now will be removed from the Kubernetes objects.
     """
-    patch_labels = {}
-    patch_labels.update(labels)
-    stateful_set = client.get(res=StatefulSet, name=app_name)
-    service = client.get(res=Service, name=app_name)
+    patch_labels: Dict[str, Optional[str]] = dict(labels)
     try:
         config_map = client.get(ConfigMap, label_configmap_name)
     except httpx.HTTPStatusError as e:
@@ -670,19 +667,22 @@ def reconcile_charm_labels(client: Client, app_name: str, namespace: str,  label
             if label not in patch_labels:
                 # The label was previously set. Setting it to None will delete it.
                 patch_labels[label] = None
-    if stateful_set.spec:
-        stateful_set.spec.template.metadata.labels.update(patch_labels)  # type: ignore
-    if service.metadata:
-        service.metadata.labels = service.metadata.labels or {}
-        service.metadata.labels.update(patch_labels)
+
+    # Do a least intrusive patch.
+    # This minimal approach eliminates the chance of 409 conflicts with other actors modifying the resources.
+    # Retrying here is a bad idea as we WANT to get a 409 when someone else patches OUR labels. We shouldn't mask that.
+    client.patch(res=StatefulSet, name=app_name, obj={
+        "spec": {"template": {"metadata": {"labels": patch_labels}}}
+    })
+    client.patch(res=Service, name=app_name, obj={
+        "metadata": {"labels": patch_labels}
+    })
 
     # Store our actively managed labels in a ConfigMap so next call we know which we might need to delete.
     # This should not include any labels that are nulled out as they're now out of scope.
     config_map_labels = {k: v for k, v in patch_labels.items() if v is not None}
     config_map.data = {"labels": json.dumps(config_map_labels)}
     client.patch(res=ConfigMap, name=label_configmap_name, obj=config_map)
-    client.patch(res=StatefulSet, name=app_name, obj=stateful_set)
-    client.patch(res=Service, name=app_name, obj=service)
 
 
 def _init_label_configmap(client, name, namespace) -> ConfigMap:

--- a/lib/charms/istio_beacon_k8s/v0/service_mesh.py
+++ b/lib/charms/istio_beacon_k8s/v0/service_mesh.py
@@ -668,8 +668,8 @@ def reconcile_charm_labels(client: Client, app_name: str, namespace: str,  label
                 # The label was previously set. Setting it to None will delete it.
                 patch_labels[label] = None
 
-    # Do a least intrusive patch.
-    # This minimal approach eliminates the chance of 409 conflicts with other actors modifying the resources.
+    # Patch just the labels instead of the entire resource defintion.
+    # This minimal approach reduces the chance of 409 conflicts when other actors are modifying the resources.
     # Retrying here is a bad idea as we WANT to get a 409 when someone else patches OUR labels. We shouldn't mask that.
     client.patch(res=StatefulSet, name=app_name, obj={
         "spec": {"template": {"metadata": {"labels": patch_labels}}}

--- a/uv.lock
+++ b/uv.lock
@@ -1263,7 +1263,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'dev'" },
     { name = "jubilant", marker = "extra == 'dev'" },
     { name = "juju", marker = "extra == 'dev'" },
-    { name = "lightkube-extensions", git = "https://github.com/canonical/lightkube-extensions.git?rev=feat%2FSMS-576-enable_raw_policy_reconciliation" },
+    { name = "lightkube-extensions", specifier = ">=0.3.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = "==1.21.0" },
     { name = "ops", specifier = "~=2.5" },
     { name = "ops-scenario", marker = "extra == 'dev'", specifier = "~=7.0" },
@@ -1396,11 +1396,15 @@ wheels = [
 
 [[package]]
 name = "lightkube-extensions"
-version = "999.999.999"
-source = { git = "https://github.com/canonical/lightkube-extensions.git?rev=feat%2FSMS-576-enable_raw_policy_reconciliation#bcf4dcb176fbf52d09f7cbaa000e11724b3abd19" }
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
     { name = "lightkube" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/b3/2e19927719909931d98f91a960f43fba4ead937005be0de599247af0d3d9/lightkube_extensions-0.3.0.tar.gz", hash = "sha256:997c5f7457c297449083ee66dce498a1a5a6423d58d4f87258cf68da04bb99f2", size = 17932, upload-time = "2025-12-19T10:43:56.561Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/0e/0681f0cf50a883af99e600b0077c070bc6f58142ae5ecb724aa1c7389319/lightkube_extensions-0.3.0-py3-none-any.whl", hash = "sha256:580178f937be39b378158264e926d6f188a05d13dd17d8491c2f1f6a234ebaf8", size = 19026, upload-time = "2025-12-19T10:43:57.481Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Issue
Fixes #133 

## Context
The patching fn that patches labels on the consumer charms was basically fetching the entire resource description, and patching the labels and reapplying the whole resource description. This is an intrusive approach and causes issues when someone else patches a different part of the resource between us getting the resource definition and patching the resource with our labels. (happens with the coordinated workers when the `cosl` is applying the resource limits and we're applying the labels for ex.)

## Solution
This PR refactors this intrusive patch operation to only patch the labels we own. We don't really care about other resource definitions. This also prevents 409s with the k8s API because we own the label. This is also a reason we should not retry the patching operation because that might mask an actual issue of someone else editing service mesh labels.


## Testing Instructions
Just a refactor. just deploy anything with mesh and make sure the consumer charms are on the mesh with the required labels.