### PR TITLE
test: migrate to pytest jubilant 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
     # Integration
     "juju",
     "jubilant",
-    "pytest-jubilant",
+    "pytest-jubilant>=2,<3",
     "httpx",
     "tenacity",
 ]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -8,9 +8,8 @@ import shutil
 from pathlib import Path
 
 import pytest
-from helpers import istio_k8s
+from helpers import get_resources, istio_k8s, pack
 from jubilant import all_active
-from pytest_jubilant import get_resources, pack
 
 
 @pytest.fixture(scope="session")
@@ -26,7 +25,7 @@ def istio_beacon_charm():
 @pytest.fixture(scope="session")
 def istio_beacon_resources():
     """Extract resources from charmcraft.yaml."""
-    return get_resources(".")
+    return get_resources("charmcraft.yaml")
 
 
 @pytest.fixture(scope="session")
@@ -49,14 +48,14 @@ def service_mesh_tester():
 @pytest.fixture(scope="session")
 def tester_resources():
     """Extract tester charm resources."""
-    return get_resources("./tests/integration/testers/service-mesh-tester")
+    return get_resources("./tests/integration/testers/service-mesh-tester/charmcraft.yaml")
 
 
 @pytest.fixture(scope="module")
-def istio_juju(temp_model_factory):
+def istio_juju(juju_factory):
     """Deploy istio-k8s in istio-system model."""
-    # Use temp_model_factory to create model - automatically respects --keep-models
-    istio_juju_model = temp_model_factory.get_juju("istio-system")
+    # Use juju_factory to create model - automatically respects --keep-models
+    istio_juju_model = juju_factory.get_juju("istio-system")
 
     # Deploy istio-k8s
     istio_juju_model.deploy(

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -4,6 +4,7 @@
 # See LICENSE file for licensing details.
 
 import logging
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
@@ -241,3 +242,39 @@ def scale_application(juju: Juju, app_name: str, target_units: int):
     elif target_units < current_count:
         # Scale down - K8s models require --num-units, not named units
         juju.remove_unit(app_name, num_units=current_count - target_units)
+
+
+def pack(root: Path | str = "./", platform: str | None = None) -> Path:
+    """Pack a local charm and return it."""
+    cmd = ["charmcraft", "pack", "--project-dir", root]
+    if platform:
+        cmd.extend(["--platform", platform])
+    proc = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    # stderr looks like:
+    # > charmcraft pack
+    # Packed tempo-coordinator-k8s_ubuntu@24.04-amd64.charm
+    # Packed tempo-coordinator-k8s_ubuntu@22.04-amd64.charm
+    packed_charms = [
+        line.split()[1]
+        for line in proc.stderr.strip().splitlines()
+        if line.startswith("Packed")
+    ]
+    if not packed_charms:
+        raise ValueError(
+            "Unable to get packed charm(s)!"
+            f" ({cmd!r} completed with {proc.returncode=}, {proc.stdout=}, {proc.stderr=})"
+        )
+    if len(packed_charms) > 1:
+        raise ValueError(
+            "This charm supports multiple platforms. "
+            "Pass a `platform` argument to control which charm you're getting instead."
+        )
+    return Path(packed_charms[0]).resolve()
+
+
+def get_resources(path: str | Path = Path("charmcraft.yaml")) -> dict[str, str]:
+    meta = yaml.safe_load(Path(path).read_text())
+    return {
+        resource: data["upstream-source"]
+        for resource, data in meta["resources"].items()
+    }

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -23,7 +23,7 @@ from lightkube.resources.core_v1 import Pod
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.setup
+@pytest.mark.juju_setup
 @pytest.mark.abort_on_fail
 def test_deploy_dependencies(istio_juju: Juju):
     """Deploy istio-k8s in istio-system model."""
@@ -34,7 +34,7 @@ def test_deploy_dependencies(istio_juju: Juju):
     assert status.apps[istio_k8s.application_name].is_active
 
 
-@pytest.mark.setup
+@pytest.mark.juju_setup
 @pytest.mark.abort_on_fail
 def test_deployment(juju: Juju, istio_beacon_charm, istio_beacon_resources):
     """Deploy istio-beacon-k8s charm."""
@@ -51,7 +51,7 @@ def test_deployment(juju: Juju, istio_beacon_charm, istio_beacon_resources):
         successes=3,
     )
 
-@pytest.mark.setup
+@pytest.mark.juju_setup
 @pytest.mark.abort_on_fail
 def test_istio_beacon_is_on_the_mesh(juju: Juju):
     """Test that the istio-beacon is on the mesh."""
@@ -66,7 +66,7 @@ def test_istio_beacon_is_on_the_mesh(juju: Juju):
     assert beacon_pod.metadata.annotations.get("ambient.istio.io/redirection", None) == "enabled"
 
 
-@pytest.mark.setup
+@pytest.mark.juju_setup
 @pytest.mark.abort_on_fail
 def test_deploy_service_mesh_apps(juju: Juju, service_mesh_tester):
     """Deploy the required tester apps onto the test model required for testing service mesh relation.

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -314,15 +314,15 @@ def test_peer_communication_in_scaled_service_mesh_consumer(juju: Juju, peer_com
 
 
 @pytest.mark.abort_on_fail
-def test_modeloperator_rule(juju: Juju, service_mesh_tester, tester_resources, temp_model_factory):
+def test_modeloperator_rule(juju: Juju, service_mesh_tester, tester_resources, juju_factory):
     """Test that we allow anything, even off-mesh workloads, to talk to the modeloperator in beacon's namespace."""
     base_model = juju.model
 
     # Ensure model is on mesh
     juju.config(APP_NAME, {"model-on-mesh": "true"})
 
-    # Create off-mesh model using temp_model_factory - respects --keep-models
-    omm_juju = temp_model_factory.get_juju("off-mesh-model")
+    # Create off-mesh model using juju_factory - respects --keep-models
+    omm_juju = juju_factory.get_juju("off-mesh-model")
 
     # Deploy sender in off-mesh model
     resources = {"echo-server-image": "jmalloc/echo-server:v0.3.7"}

--- a/tests/integration/test_charm_scaling.py
+++ b/tests/integration/test_charm_scaling.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 TESTER_APP_NAME = "tester"
 
 
-@pytest.mark.setup
+@pytest.mark.juju_setup
 @pytest.mark.abort_on_fail
 def test_deploy_dependencies(istio_juju: Juju):
     """Deploy istio-k8s in istio-system model."""
@@ -32,7 +32,7 @@ def test_deploy_dependencies(istio_juju: Juju):
     assert status.apps[istio_k8s.application_name].is_active
 
 
-@pytest.mark.setup
+@pytest.mark.juju_setup
 @pytest.mark.abort_on_fail
 def test_deployment(juju: Juju, istio_beacon_charm, istio_beacon_resources):
     """Deploy istio-beacon-k8s charm."""
@@ -50,7 +50,7 @@ def test_deployment(juju: Juju, istio_beacon_charm, istio_beacon_resources):
     )
 
 
-@pytest.mark.setup
+@pytest.mark.juju_setup
 @pytest.mark.abort_on_fail
 def test_service_mesh_relation(juju: Juju, service_mesh_tester):
     """Adds a tester charm and creates a service mesh relation between beacon and the tester charm.

--- a/tests/integration/test_cross_model.py
+++ b/tests/integration/test_cross_model.py
@@ -17,16 +17,16 @@ from jubilant import Juju, all_active
 
 
 @pytest.fixture(scope="module")
-def sender_model(temp_model_factory):
+def sender_model(juju_factory):
     """Create and return a Juju instance for the sender model."""
-    sender_model = temp_model_factory.get_juju("sender")
+    sender_model = juju_factory.get_juju("sender")
     return sender_model
 
 
 @pytest.fixture(scope="module")
-def receiver_model(temp_model_factory):
+def receiver_model(juju_factory):
     """Create and return a Juju instance for the receiver model."""
-    receiver_model = temp_model_factory.get_juju("receiver")
+    receiver_model = juju_factory.get_juju("receiver")
     return receiver_model
 
 

--- a/tests/integration/test_cross_model.py
+++ b/tests/integration/test_cross_model.py
@@ -30,7 +30,7 @@ def receiver_model(juju_factory):
     return receiver_model
 
 
-@pytest.mark.setup
+@pytest.mark.juju_setup
 @pytest.mark.abort_on_fail
 def test_deploy_istio_dependencies(istio_juju: Juju):
     """Deploy istio-k8s in istio-system model."""
@@ -41,7 +41,7 @@ def test_deploy_istio_dependencies(istio_juju: Juju):
     assert status.apps[istio_k8s.application_name].is_active
 
 
-@pytest.mark.setup
+@pytest.mark.juju_setup
 @pytest.mark.abort_on_fail
 def test_deploy_environment(
     sender_model: Juju,

--- a/tests/integration/test_policy_resource_manager.py
+++ b/tests/integration/test_policy_resource_manager.py
@@ -92,7 +92,7 @@ def assert_policy_accepted(lightkube_client: Client, policy_name: str, namespace
     assert accepted, f"Policy {policy_name} not accepted. Conditions: {conditions}"
 
 
-@pytest.mark.setup
+@pytest.mark.juju_setup
 @pytest.mark.abort_on_fail
 def test_deploy_beacon(
     juju: Juju, istio_juju: Juju, istio_beacon_charm, istio_beacon_resources

--- a/uv.lock
+++ b/uv.lock
@@ -1270,7 +1270,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2" },
     { name = "pyright", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
-    { name = "pytest-jubilant", marker = "extra == 'dev'" },
+    { name = "pytest-jubilant", marker = "extra == 'dev'", specifier = ">=2,<3" },
     { name = "pytest-mock", marker = "extra == 'dev'" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "tenacity", marker = "extra == 'dev'" },
@@ -2291,7 +2291,7 @@ wheels = [
 
 [[package]]
 name = "pytest-jubilant"
-version = "1.1"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jubilant" },
@@ -2299,9 +2299,9 @@ dependencies = [
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
     { name = "pytest", version = "9.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/73/01/a089e0b323d87519e19425809062090a615cc10fdf8879ecf0ec5c5dfc36/pytest_jubilant-1.1.tar.gz", hash = "sha256:755dd5a1b4c295773a01ed3005cec1bd106a46bf51ec041ae56004dd558e8f9c", size = 12368, upload-time = "2025-07-28T06:42:44.808Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/b6/d98999f1d0a0c9313154fe7bf8f4e3639729b7052c736f2f12cd7025201c/pytest_jubilant-2.0.0.tar.gz", hash = "sha256:c5f8382ac0b43bca8ef87e309f587e2fc1751ff7b2677dd28a66989b6605e063", size = 16250, upload-time = "2026-03-29T23:39:57.966Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/e2/0d9124119c994aba4fbb48457a3dde01d5af5db1cd095be7b03bc6b21215/pytest_jubilant-1.1-py3-none-any.whl", hash = "sha256:1c643b0e64173e405988074e551dd2101805412d807c3c0e51983b52f8b198d4", size = 12040, upload-time = "2025-07-28T06:42:43.518Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c3/234c3ec22b230e7e33732f91d19d72ad84101a97353b03be3450e4188c5c/pytest_jubilant-2.0.0-py3-none-any.whl", hash = "sha256:28fcf3750100eda16658c2967af099a39199af9fd102ab3b5ba230a028efec3e", size = 13354, upload-time = "2026-03-29T23:39:56.66Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

The `pytest-jubilant` [2.0 release](https://github.com/canonical/pytest-jubilant/releases/tag/v2.0.0) breaks this repo's tests.

## Solution
<!-- A summary of the solution addressing the above issue -->

This PR migrates the tests to use the 2.0 API. This includes defining copies of the `pack` and `get_resources` helpers dropped from `pytest-jubilant`.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

Charm Tech will maintain the `pytest-jubilant` 2.0 API going forward. We dropped `pack` and `get_resources` to scope the library more tightly to `pytest` + `jubilant`. In general, we think it's cleaner to avoid calling `charmcraft pack` inside your Python integration test suite.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Integration tests should pass.

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->

N/A.