### PR TITLE
fix: include icon.svg in final the charm file

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -20,6 +20,11 @@ parts:
     override-build: |
       craftctl default
       git describe --always > $CRAFT_PART_INSTALL/version
+  extra-files:
+    plugin: dump
+    source: .
+    stage:
+      - icon.svg
 
 containers:
   metrics-proxy:


### PR DESCRIPTION
The icon file must be explicitly referenced to be included in the final .charm file.