### PR TITLE
chore: explicit optional value for endpoints

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -49,6 +49,7 @@ resources:
 provides:
   provide-cmr-mesh:
     interface: cross_model_mesh
+    optional: true
   service-mesh:
     interface: service_mesh
     optional: true


### PR DESCRIPTION
Endpoints should explicitly state the `optional` key according to [the best practices](https://documentation.ubuntu.com/ops/latest/howto/write-and-structure-charm-code/) in the documentation:

> Include the `optional` key in all endpoint definitions, rather than relying on the default value to indicate that the relation is required. [...]